### PR TITLE
Added change to alert feat

### DIFF
--- a/packs/_source/feats/alert.json
+++ b/packs/_source/feats/alert.json
@@ -8,9 +8,9 @@
       "_id": "cOPS96jeTb8E0cQS",
       "changes": [
         {
-          "key": "flags.sw5e.initiativeAlert",
-          "value": "1",
-          "mode": 0,
+          "key": "system.attributes.init.bonus",
+          "value": "@prof",
+          "mode": 2,
           "priority": 20
         }
       ],


### PR DESCRIPTION
- will now correctly add proficiency to initiative

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated the "Alert" feature to enhance initiative bonus calculations, transitioning from a static to a dynamic system based on proficiency.
  
- **Bug Fixes**
	- Preserved overall structure while ensuring the initiative bonus mechanics function correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->