### PR TITLE
Fix legacy Advancement IDs during DND5e 5.3 migration

### DIFF
--- a/scripts/dnd5e-source-normalization.mjs
+++ b/scripts/dnd5e-source-normalization.mjs
@@ -613,8 +613,20 @@ export function normalizeLegacyItemAdvancement(item) {
 		const asObject = {}
 		for ( const entry of rawAdvancement ) {
 			if ( !isObjectLike(entry) ) continue
-			// Match upstream: key by existing `_id` only; do not fabricate IDs.
-			if ( typeof entry._id === "string" && entry._id ) asObject[entry._id] = entry
+
+			// Preserve existing Advancement IDs, but generate a Foundry ID for
+			// legacy SW5E entries which do not have one. Object-native DND5e
+			// storage is keyed by the same ID stored in advancement._id.
+			let advancementId = (typeof entry._id === "string" && entry._id)
+				? entry._id
+				: foundry.utils.randomID()
+
+			// Prevent an accidental overwrite if malformed legacy data contains
+			// duplicate Advancement IDs.
+			while ( asObject[advancementId] ) advancementId = foundry.utils.randomID()
+
+			entry._id = advancementId
+			asObject[advancementId] = entry
 		}
 		item.system.advancement = asObject
 		advancement = asObject


### PR DESCRIPTION
## Summary

Fix legacy SW5E Advancement migration so array-form advancements are not dropped when they lack an `_id`.

## Changes

- Preserve an existing Advancement `_id` when present.
- Generate a Foundry `randomID()` for legacy Advancement entries that do not have an `_id`.
- Regenerate an ID if duplicate legacy IDs would otherwise overwrite one another.
- Store each Advancement in DND5e 5.3 object-native `system.advancement` keyed by the same `_id`.
- Leave the existing normalization of `configuration`, `value`, and ScaleValue data unchanged.

## Why

The current migration only copies legacy array entries that already contain an `_id`. Legacy SW5E Advancement entries without `_id` are therefore omitted when converting the array to DND5e 5.3 object storage, which can erase class Advancement data during migration.

## Testing

Recommended migration test from a fresh pre-migration V13/SW5E 1.4.3 world:

1. Record the Advancement count on several class items before migration.
2. Migrate to V14 / dnd5e 5.3.3 with this branch.
3. Confirm the same Advancement count remains after migration.
4. Confirm every migrated Advancement has an `_id` matching its `system.advancement` object key.
5. Include at least one class with legacy Advancement entries that do not already have `_id` values.
