### PR TITLE
Adapt SW5e starship movement for dnd5e 6.0

### DIFF
--- a/packs/_source/deployments/operator/deployment-features/overload-systems.yml
+++ b/packs/_source/deployments/operator/deployment-features/overload-systems.yml
@@ -9,7 +9,7 @@ effects:
         mode: 1
         value: '.5'
         priority: 20
-      - key: system.attributes.movement.turn
+      - key: system.attributes.movement.speeds.turn
         mode: 1
         value: '2'
         priority: 20

--- a/packs/_source/drakes-shipyard/akajor-class-shuttle.yml
+++ b/packs/_source/drakes-shipyard/akajor-class-shuttle.yml
@@ -2517,7 +2517,7 @@ items:
     effects:
       - _id: yie6lRqE4olXJrK3
         changes:
-          - key: system.attributes.movement.turn
+          - key: system.attributes.movement.speeds.turn
             mode: 2
             value: '+100'
             priority: 20
@@ -3717,7 +3717,7 @@ effects:
     _key: '!actors.effects!tRnGAAILKowm8n4T.ljLwuvSxNPAaYg0h'
   - _id: 0RlB54eJOemGnAg4
     changes:
-      - key: system.attributes.movement.turn
+      - key: system.attributes.movement.speeds.turn
         mode: 2
         value: '+100'
         priority: 20

--- a/packs/_source/drakes-shipyard/arquitens-class-command-cruiser.yml
+++ b/packs/_source/drakes-shipyard/arquitens-class-command-cruiser.yml
@@ -3535,7 +3535,7 @@ items:
             mode: 2
             value: '-50'
             priority: 20
-          - key: system.attributes.movement.turn
+          - key: system.attributes.movement.speeds.turn
             mode: 2
             value: '+50'
             priority: 20
@@ -3730,7 +3730,7 @@ items:
             mode: 2
             value: '-50'
             priority: 20
-          - key: system.attributes.movement.turn
+          - key: system.attributes.movement.speeds.turn
             mode: 2
             value: '+50'
             priority: 20
@@ -11290,7 +11290,7 @@ effects:
         mode: 2
         value: '-50'
         priority: 20
-      - key: system.attributes.movement.turn
+      - key: system.attributes.movement.speeds.turn
         mode: 2
         value: '+50'
         priority: 20
@@ -11332,7 +11332,7 @@ effects:
         mode: 2
         value: '-50'
         priority: 20
-      - key: system.attributes.movement.turn
+      - key: system.attributes.movement.speeds.turn
         mode: 2
         value: '+50'
         priority: 20

--- a/packs/_source/drakes-shipyard/arquitens-class-light-cruiser.yml
+++ b/packs/_source/drakes-shipyard/arquitens-class-light-cruiser.yml
@@ -3535,7 +3535,7 @@ items:
             mode: 2
             value: '-50'
             priority: 20
-          - key: system.attributes.movement.turn
+          - key: system.attributes.movement.speeds.turn
             mode: 2
             value: '+50'
             priority: 20
@@ -3730,7 +3730,7 @@ items:
             mode: 2
             value: '-50'
             priority: 20
-          - key: system.attributes.movement.turn
+          - key: system.attributes.movement.speeds.turn
             mode: 2
             value: '+50'
             priority: 20
@@ -10109,7 +10109,7 @@ effects:
         mode: 2
         value: '-50'
         priority: 20
-      - key: system.attributes.movement.turn
+      - key: system.attributes.movement.speeds.turn
         mode: 2
         value: '+50'
         priority: 20
@@ -10151,7 +10151,7 @@ effects:
         mode: 2
         value: '-50'
         priority: 20
-      - key: system.attributes.movement.turn
+      - key: system.attributes.movement.speeds.turn
         mode: 2
         value: '+50'
         priority: 20

--- a/packs/_source/drakes-shipyard/baudo-class-star-yacht-modified.yml
+++ b/packs/_source/drakes-shipyard/baudo-class-star-yacht-modified.yml
@@ -7244,7 +7244,7 @@ items:
             mode: 2
             value: '-50'
             priority: 20
-          - key: system.attributes.movement.turn
+          - key: system.attributes.movement.speeds.turn
             mode: 2
             value: '+50'
             priority: 20
@@ -10561,7 +10561,7 @@ effects:
         mode: 2
         value: '-50'
         priority: 20
-      - key: system.attributes.movement.turn
+      - key: system.attributes.movement.speeds.turn
         mode: 2
         value: '+50'
         priority: 20

--- a/packs/_source/drakes-shipyard/cr90-corvette.yml
+++ b/packs/_source/drakes-shipyard/cr90-corvette.yml
@@ -3092,7 +3092,7 @@ items:
             mode: 2
             value: '-50'
             priority: 20
-          - key: system.attributes.movement.turn
+          - key: system.attributes.movement.speeds.turn
             mode: 2
             value: '+50'
             priority: 20
@@ -8230,7 +8230,7 @@ effects:
         mode: 2
         value: '-50'
         priority: 20
-      - key: system.attributes.movement.turn
+      - key: system.attributes.movement.speeds.turn
         mode: 2
         value: '+50'
         priority: 20

--- a/packs/_source/drakes-shipyard/delta-7-aethersprite-class-light-interceptor-modified.yml
+++ b/packs/_source/drakes-shipyard/delta-7-aethersprite-class-light-interceptor-modified.yml
@@ -6768,7 +6768,7 @@ items:
     effects:
       - _id: yie6lRqE4olXJrK3
         changes:
-          - key: system.attributes.movement.turn
+          - key: system.attributes.movement.speeds.turn
             mode: 2
             value: '+100'
             priority: 20
@@ -9633,7 +9633,7 @@ effects:
     _key: '!actors.effects!FbzPxDn1FfeRvDym.FRvf5uD07MbmwFdA'
   - _id: 1zY7dlV8Yg3x1bC2
     changes:
-      - key: system.attributes.movement.turn
+      - key: system.attributes.movement.speeds.turn
         mode: 2
         value: '+100'
         priority: 20

--- a/packs/_source/drakes-shipyard/ef76-nebulon-b-escort-frigate-medical.yml
+++ b/packs/_source/drakes-shipyard/ef76-nebulon-b-escort-frigate-medical.yml
@@ -7513,7 +7513,7 @@ items:
             mode: 2
             value: '-50'
             priority: 20
-          - key: system.attributes.movement.turn
+          - key: system.attributes.movement.speeds.turn
             mode: 2
             value: '+50'
             priority: 20
@@ -10113,7 +10113,7 @@ items:
     effects:
       - _id: yie6lRqE4olXJrK3
         changes:
-          - key: system.attributes.movement.turn
+          - key: system.attributes.movement.speeds.turn
             mode: 2
             value: '+100'
             priority: 20
@@ -15029,7 +15029,7 @@ effects:
         mode: 2
         value: '50'
         priority: 20
-      - key: system.attributes.movement.turn
+      - key: system.attributes.movement.speeds.turn
         mode: 2
         value: '-150'
         priority: 20
@@ -15168,7 +15168,7 @@ effects:
         value: '-50'
         mode: 2
         priority: 20
-      - key: system.attributes.movement.turn
+      - key: system.attributes.movement.speeds.turn
         value: '+50'
         mode: 2
         priority: 20
@@ -15290,7 +15290,7 @@ effects:
     _key: '!actors.effects!8uUUatfcGjYMSKZr.g3fQJGvFfA5Avr5a'
   - _id: oR76VvJHehmqDILW
     changes:
-      - key: system.attributes.movement.turn
+      - key: system.attributes.movement.speeds.turn
         value: '+100'
         mode: 2
         priority: 20

--- a/packs/_source/drakes-shipyard/ef76-nebulon-b-escort-frigate.yml
+++ b/packs/_source/drakes-shipyard/ef76-nebulon-b-escort-frigate.yml
@@ -2432,7 +2432,7 @@ items:
             mode: 2
             value: '-50'
             priority: 20
-          - key: system.attributes.movement.turn
+          - key: system.attributes.movement.speeds.turn
             mode: 2
             value: '+50'
             priority: 20
@@ -4283,7 +4283,7 @@ items:
     effects:
       - _id: yie6lRqE4olXJrK3
         changes:
-          - key: system.attributes.movement.turn
+          - key: system.attributes.movement.speeds.turn
             mode: 2
             value: '+100'
             priority: 20
@@ -15827,7 +15827,7 @@ effects:
         mode: 2
         value: '50'
         priority: 20
-      - key: system.attributes.movement.turn
+      - key: system.attributes.movement.speeds.turn
         mode: 2
         value: '-150'
         priority: 20
@@ -15911,7 +15911,7 @@ effects:
         value: '-50'
         mode: 2
         priority: 20
-      - key: system.attributes.movement.turn
+      - key: system.attributes.movement.speeds.turn
         value: '+50'
         mode: 2
         priority: 20
@@ -16033,7 +16033,7 @@ effects:
     _key: '!actors.effects!MBlMVJlmhIjF9IqH.gUFElYjnIsQjlJi1'
   - _id: cZc3a7HVDTQokPIZ
     changes:
-      - key: system.attributes.movement.turn
+      - key: system.attributes.movement.speeds.turn
         value: '+100'
         mode: 2
         priority: 20

--- a/packs/_source/drakes-shipyard/fang-class.yml
+++ b/packs/_source/drakes-shipyard/fang-class.yml
@@ -2758,7 +2758,7 @@ items:
     effects:
       - _id: yie6lRqE4olXJrK3
         changes:
-          - key: system.attributes.movement.turn
+          - key: system.attributes.movement.speeds.turn
             mode: 2
             value: '+100'
             priority: 20
@@ -7300,7 +7300,7 @@ effects:
         value: '0'
         mode: 2
         priority: 20
-      - key: system.attributes.movement.turn
+      - key: system.attributes.movement.speeds.turn
         value: '-100'
         mode: 2
         priority: 20
@@ -7422,7 +7422,7 @@ effects:
     _key: '!actors.effects!uAzqh6bUJ4ZfKcol.8j6BCOP5RHQNSdII'
   - _id: S8A94ZI66ZMscLNU
     changes:
-      - key: system.attributes.movement.turn
+      - key: system.attributes.movement.speeds.turn
         value: '+100'
         mode: 2
         priority: 20

--- a/packs/_source/drakes-shipyard/gat-12-skipray-blastboat.yml
+++ b/packs/_source/drakes-shipyard/gat-12-skipray-blastboat.yml
@@ -2558,7 +2558,7 @@ items:
     effects:
       - _id: yie6lRqE4olXJrK3
         changes:
-          - key: system.attributes.movement.turn
+          - key: system.attributes.movement.speeds.turn
             mode: 2
             value: '+100'
             priority: 20
@@ -8729,7 +8729,7 @@ effects:
     _key: '!actors.effects!Bgqr4WNQpTzEIepj.RBy6DhM3bBSJXtAm'
   - _id: lEiFFloq2ZkkeApZ
     changes:
-      - key: system.attributes.movement.turn
+      - key: system.attributes.movement.speeds.turn
         value: '+100'
         mode: 2
         priority: 20

--- a/packs/_source/drakes-shipyard/hmp-droid-gunship.yml
+++ b/packs/_source/drakes-shipyard/hmp-droid-gunship.yml
@@ -8419,7 +8419,7 @@ effects:
         mode: 2
         value: '0'
         priority: 20
-      - key: system.attributes.movement.turn
+      - key: system.attributes.movement.speeds.turn
         mode: 5
         value: '400'
         priority: 20

--- a/packs/_source/drakes-shipyard/nantex-class-territorial-defense-starfighter.yml
+++ b/packs/_source/drakes-shipyard/nantex-class-territorial-defense-starfighter.yml
@@ -2765,7 +2765,7 @@ items:
     effects:
       - _id: yie6lRqE4olXJrK3
         changes:
-          - key: system.attributes.movement.turn
+          - key: system.attributes.movement.speeds.turn
             mode: 2
             value: '+100'
             priority: 20
@@ -4246,7 +4246,7 @@ effects:
     _key: '!actors.effects!bc83jDYGauWHxSjB.dsG0ECXmfhLqvpaz'
   - _id: nHTMkXmN6eLbCcC4
     changes:
-      - key: system.attributes.movement.turn
+      - key: system.attributes.movement.speeds.turn
         value: '+100'
         mode: 2
         priority: 20

--- a/packs/_source/drakes-shipyard/u-wing-starfighter-support-craft-ut-60d.yml
+++ b/packs/_source/drakes-shipyard/u-wing-starfighter-support-craft-ut-60d.yml
@@ -3736,7 +3736,7 @@ items:
     effects:
       - _id: yie6lRqE4olXJrK3
         changes:
-          - key: system.attributes.movement.turn
+          - key: system.attributes.movement.speeds.turn
             mode: 2
             value: '+100'
             priority: 20
@@ -6756,7 +6756,7 @@ effects:
     _key: '!actors.effects!8rxZGWKJJ2XbyhNl.nNmvWRzLgR4CFx4y'
   - _id: QGnsGnvvr3bFRZMx
     changes:
-      - key: system.attributes.movement.turn
+      - key: system.attributes.movement.speeds.turn
         value: '+100'
         mode: 2
         priority: 20

--- a/packs/_source/drakes-shipyard/vcx-100-light-freighter-modified.yml
+++ b/packs/_source/drakes-shipyard/vcx-100-light-freighter-modified.yml
@@ -3450,7 +3450,7 @@ items:
             mode: 2
             value: '-50'
             priority: 20
-          - key: system.attributes.movement.turn
+          - key: system.attributes.movement.speeds.turn
             mode: 2
             value: '+50'
             priority: 20
@@ -11757,7 +11757,7 @@ effects:
         mode: 2
         value: '-50'
         priority: 20
-      - key: system.attributes.movement.turn
+      - key: system.attributes.movement.speeds.turn
         mode: 2
         value: '+50'
         priority: 20

--- a/packs/_source/drakes-shipyard/vcx-100-light-freighter.yml
+++ b/packs/_source/drakes-shipyard/vcx-100-light-freighter.yml
@@ -3442,7 +3442,7 @@ items:
             mode: 2
             value: '-50'
             priority: 20
-          - key: system.attributes.movement.turn
+          - key: system.attributes.movement.speeds.turn
             mode: 2
             value: '+50'
             priority: 20
@@ -6297,7 +6297,7 @@ effects:
         mode: 2
         value: '-50'
         priority: 20
-      - key: system.attributes.movement.turn
+      - key: system.attributes.movement.speeds.turn
         mode: 2
         value: '+50'
         priority: 20

--- a/packs/_source/drakes-shipyard/vt-49-decimator.yml
+++ b/packs/_source/drakes-shipyard/vt-49-decimator.yml
@@ -4069,7 +4069,7 @@ items:
             mode: 2
             value: '-50'
             priority: 20
-          - key: system.attributes.movement.turn
+          - key: system.attributes.movement.speeds.turn
             mode: 2
             value: '+50'
             priority: 20
@@ -8387,7 +8387,7 @@ effects:
         value: '-50'
         mode: 2
         priority: 20
-      - key: system.attributes.movement.turn
+      - key: system.attributes.movement.speeds.turn
         value: '+50'
         mode: 2
         priority: 20
@@ -8654,7 +8654,7 @@ effects:
         mode: 5
         value: '300'
         priority: 20
-      - key: system.attributes.movement.turn
+      - key: system.attributes.movement.speeds.turn
         mode: 5
         value: '200'
         priority: 20

--- a/packs/_source/drakes-shipyard/wayfarer-class-medium-transport.yml
+++ b/packs/_source/drakes-shipyard/wayfarer-class-medium-transport.yml
@@ -6849,7 +6849,7 @@ effects:
         mode: 2
         value: '1'
         priority: 20
-      - key: system.attributes.movement.turn
+      - key: system.attributes.movement.speeds.turn
         mode: 2
         value: '50'
         priority: 20

--- a/packs/_source/drakes-shipyard/yt-1300-heavily-modified.yml
+++ b/packs/_source/drakes-shipyard/yt-1300-heavily-modified.yml
@@ -4385,7 +4385,7 @@ items:
             mode: 2
             value: '-50'
             priority: 20
-          - key: system.attributes.movement.turn
+          - key: system.attributes.movement.speeds.turn
             mode: 2
             value: '+50'
             priority: 20
@@ -10076,7 +10076,7 @@ effects:
         value: '-50'
         mode: 2
         priority: 20
-      - key: system.attributes.movement.turn
+      - key: system.attributes.movement.speeds.turn
         value: '+50'
         mode: 2
         priority: 20
@@ -10595,7 +10595,7 @@ effects:
         mode: 5
         value: '400'
         priority: 20
-      - key: system.attributes.movement.turn
+      - key: system.attributes.movement.speeds.turn
         mode: 5
         value: '150'
         priority: 20

--- a/packs/_source/drakes-shipyard/yv-929-armed-freighter.yml
+++ b/packs/_source/drakes-shipyard/yv-929-armed-freighter.yml
@@ -6754,7 +6754,7 @@ effects:
         mode: 5
         value: '350'
         priority: 20
-      - key: system.attributes.movement.turn
+      - key: system.attributes.movement.speeds.turn
         mode: 5
         value: '300'
         priority: 20

--- a/packs/_source/starships/starship-features/gargantuan/role-blockade-ship.yml
+++ b/packs/_source/starships/starship-features/gargantuan/role-blockade-ship.yml
@@ -15,11 +15,11 @@ effects:
         mode: 2
         value: '1'
         priority: 1
-      - key: system.attributes.movement.space
+      - key: system.attributes.movement.speeds.space
         mode: 5
         value: '100'
         priority: 20
-      - key: system.attributes.movement.turn
+      - key: system.attributes.movement.speeds.turn
         mode: 5
         value: '400'
         priority: 20

--- a/packs/_source/starships/starship-features/gargantuan/role-flagship.yml
+++ b/packs/_source/starships/starship-features/gargantuan/role-flagship.yml
@@ -15,11 +15,11 @@ effects:
         mode: 2
         value: '1'
         priority: 1
-      - key: system.attributes.movement.space
+      - key: system.attributes.movement.speeds.space
         mode: 5
         value: '200'
         priority: 20
-      - key: system.attributes.movement.turn
+      - key: system.attributes.movement.speeds.turn
         mode: 5
         value: '500'
         priority: 20

--- a/packs/_source/starships/starship-features/gargantuan/role-industrial-center.yml
+++ b/packs/_source/starships/starship-features/gargantuan/role-industrial-center.yml
@@ -15,11 +15,11 @@ effects:
         mode: 2
         value: '1'
         priority: 1
-      - key: system.attributes.movement.space
+      - key: system.attributes.movement.speeds.space
         mode: 5
         value: '300'
         priority: 20
-      - key: system.attributes.movement.turn
+      - key: system.attributes.movement.speeds.turn
         mode: 5
         value: '600'
         priority: 20

--- a/packs/_source/starships/starship-features/gargantuan/role-mobile-metropolis.yml
+++ b/packs/_source/starships/starship-features/gargantuan/role-mobile-metropolis.yml
@@ -15,11 +15,11 @@ effects:
         mode: 2
         value: '1'
         priority: 1
-      - key: system.attributes.movement.space
+      - key: system.attributes.movement.speeds.space
         mode: 5
         value: '300'
         priority: 20
-      - key: system.attributes.movement.turn
+      - key: system.attributes.movement.speeds.turn
         mode: 5
         value: '600'
         priority: 20

--- a/packs/_source/starships/starship-features/gargantuan/role-researcher.yml
+++ b/packs/_source/starships/starship-features/gargantuan/role-researcher.yml
@@ -15,11 +15,11 @@ effects:
         mode: 2
         value: '1'
         priority: 1
-      - key: system.attributes.movement.space
+      - key: system.attributes.movement.speeds.space
         mode: 5
         value: '100'
         priority: 20
-      - key: system.attributes.movement.turn
+      - key: system.attributes.movement.speeds.turn
         mode: 5
         value: '400'
         priority: 20

--- a/packs/_source/starships/starship-features/gargantuan/role-warship.yml
+++ b/packs/_source/starships/starship-features/gargantuan/role-warship.yml
@@ -15,11 +15,11 @@ effects:
         mode: 2
         value: '1'
         priority: 1
-      - key: system.attributes.movement.space
+      - key: system.attributes.movement.speeds.space
         mode: 5
         value: '200'
         priority: 20
-      - key: system.attributes.movement.turn
+      - key: system.attributes.movement.speeds.turn
         mode: 5
         value: '500'
         priority: 20

--- a/packs/_source/starships/starship-features/huge/role-battleship.yml
+++ b/packs/_source/starships/starship-features/huge/role-battleship.yml
@@ -15,11 +15,11 @@ effects:
         mode: 2
         value: '1'
         priority: 1
-      - key: system.attributes.movement.space
+      - key: system.attributes.movement.speeds.space
         mode: 5
         value: '200'
         priority: 20
-      - key: system.attributes.movement.turn
+      - key: system.attributes.movement.speeds.turn
         mode: 5
         value: '400'
         priority: 20

--- a/packs/_source/starships/starship-features/huge/role-carrier.yml
+++ b/packs/_source/starships/starship-features/huge/role-carrier.yml
@@ -15,11 +15,11 @@ effects:
         mode: 2
         value: '1'
         priority: 1
-      - key: system.attributes.movement.space
+      - key: system.attributes.movement.speeds.space
         mode: 5
         value: '300'
         priority: 20
-      - key: system.attributes.movement.turn
+      - key: system.attributes.movement.speeds.turn
         mode: 5
         value: '500'
         priority: 20

--- a/packs/_source/starships/starship-features/huge/role-colonizer.yml
+++ b/packs/_source/starships/starship-features/huge/role-colonizer.yml
@@ -15,11 +15,11 @@ effects:
         mode: 2
         value: '1'
         priority: 1
-      - key: system.attributes.movement.space
+      - key: system.attributes.movement.speeds.space
         mode: 5
         value: '400'
         priority: 20
-      - key: system.attributes.movement.turn
+      - key: system.attributes.movement.speeds.turn
         mode: 5
         value: '600'
         priority: 20

--- a/packs/_source/starships/starship-features/huge/role-command-ship.yml
+++ b/packs/_source/starships/starship-features/huge/role-command-ship.yml
@@ -15,11 +15,11 @@ effects:
         mode: 2
         value: '1'
         priority: 1
-      - key: system.attributes.movement.space
+      - key: system.attributes.movement.speeds.space
         mode: 5
         value: '300'
         priority: 20
-      - key: system.attributes.movement.turn
+      - key: system.attributes.movement.speeds.turn
         mode: 5
         value: '500'
         priority: 20

--- a/packs/_source/starships/starship-features/huge/role-interdictor.yml
+++ b/packs/_source/starships/starship-features/huge/role-interdictor.yml
@@ -15,11 +15,11 @@ effects:
         mode: 2
         value: '1'
         priority: 1
-      - key: system.attributes.movement.space
+      - key: system.attributes.movement.speeds.space
         mode: 5
         value: '200'
         priority: 20
-      - key: system.attributes.movement.turn
+      - key: system.attributes.movement.speeds.turn
         mode: 5
         value: '400'
         priority: 20

--- a/packs/_source/starships/starship-features/huge/role-juggernaut.yml
+++ b/packs/_source/starships/starship-features/huge/role-juggernaut.yml
@@ -15,11 +15,11 @@ effects:
         mode: 2
         value: '1'
         priority: 1
-      - key: system.attributes.movement.space
+      - key: system.attributes.movement.speeds.space
         mode: 5
         value: '400'
         priority: 20
-      - key: system.attributes.movement.turn
+      - key: system.attributes.movement.speeds.turn
         mode: 5
         value: '600'
         priority: 20

--- a/packs/_source/starships/starship-features/large/role-ambassador.yml
+++ b/packs/_source/starships/starship-features/large/role-ambassador.yml
@@ -15,11 +15,11 @@ effects:
         mode: 2
         value: '1'
         priority: 1
-      - key: system.attributes.movement.space
+      - key: system.attributes.movement.speeds.space
         mode: 5
         value: '350'
         priority: 20
-      - key: system.attributes.movement.turn
+      - key: system.attributes.movement.speeds.turn
         mode: 5
         value: '250'
         priority: 20

--- a/packs/_source/starships/starship-features/large/role-corvette.yml
+++ b/packs/_source/starships/starship-features/large/role-corvette.yml
@@ -15,11 +15,11 @@ effects:
         mode: 0
         value: '1'
         priority: 1
-      - key: system.attributes.movement.space
+      - key: system.attributes.movement.speeds.space
         mode: 5
         value: '400'
         priority: 20
-      - key: system.attributes.movement.turn
+      - key: system.attributes.movement.speeds.turn
         mode: 5
         value: '300'
         priority: 20

--- a/packs/_source/starships/starship-features/large/role-cruiser.yml
+++ b/packs/_source/starships/starship-features/large/role-cruiser.yml
@@ -15,11 +15,11 @@ effects:
         mode: 0
         value: '1'
         priority: 1
-      - key: system.attributes.movement.space
+      - key: system.attributes.movement.speeds.space
         mode: 5
         value: '400'
         priority: 20
-      - key: system.attributes.movement.turn
+      - key: system.attributes.movement.speeds.turn
         mode: 5
         value: '300'
         priority: 20

--- a/packs/_source/starships/starship-features/large/role-explorer.yml
+++ b/packs/_source/starships/starship-features/large/role-explorer.yml
@@ -15,11 +15,11 @@ effects:
         mode: 0
         value: '1'
         priority: 1
-      - key: system.attributes.movement.space
+      - key: system.attributes.movement.speeds.space
         mode: 5
         value: '350'
         priority: 20
-      - key: system.attributes.movement.turn
+      - key: system.attributes.movement.speeds.turn
         mode: 5
         value: '250'
         priority: 20

--- a/packs/_source/starships/starship-features/large/role-picket-ship.yml
+++ b/packs/_source/starships/starship-features/large/role-picket-ship.yml
@@ -15,11 +15,11 @@ effects:
         mode: 2
         value: '1'
         priority: 1
-      - key: system.attributes.movement.space
+      - key: system.attributes.movement.speeds.space
         mode: 5
         value: '300'
         priority: 20
-      - key: system.attributes.movement.turn
+      - key: system.attributes.movement.speeds.turn
         mode: 5
         value: '200'
         priority: 20

--- a/packs/_source/starships/starship-features/large/role-ships-tender.yml
+++ b/packs/_source/starships/starship-features/large/role-ships-tender.yml
@@ -15,11 +15,11 @@ effects:
         mode: 2
         value: '1'
         priority: 1
-      - key: system.attributes.movement.space
+      - key: system.attributes.movement.speeds.space
         mode: 5
         value: '300'
         priority: 20
-      - key: system.attributes.movement.turn
+      - key: system.attributes.movement.speeds.turn
         mode: 5
         value: '200'
         priority: 20

--- a/packs/_source/starships/starship-features/medium/role-courier.yml
+++ b/packs/_source/starships/starship-features/medium/role-courier.yml
@@ -11,11 +11,11 @@ effects:
         mode: 2
         value: '1'
         priority: 1
-      - key: system.attributes.movement.space
+      - key: system.attributes.movement.speeds.space
         mode: 5
         value: '400'
         priority: 20
-      - key: system.attributes.movement.turn
+      - key: system.attributes.movement.speeds.turn
         mode: 5
         value: '250'
         priority: 20

--- a/packs/_source/starships/starship-features/medium/role-freighter.yml
+++ b/packs/_source/starships/starship-features/medium/role-freighter.yml
@@ -11,11 +11,11 @@ effects:
         mode: 2
         value: '1'
         priority: 1
-      - key: system.attributes.movement.space
+      - key: system.attributes.movement.speeds.space
         mode: 5
         value: '300'
         priority: 20
-      - key: system.attributes.movement.turn
+      - key: system.attributes.movement.speeds.turn
         mode: 5
         value: '150'
         priority: 20

--- a/packs/_source/starships/starship-features/medium/role-gunship.yml
+++ b/packs/_source/starships/starship-features/medium/role-gunship.yml
@@ -11,11 +11,11 @@ effects:
         mode: 2
         value: '1'
         priority: 1
-      - key: system.attributes.movement.space
+      - key: system.attributes.movement.speeds.space
         mode: 5
         value: '300'
         priority: 20
-      - key: system.attributes.movement.turn
+      - key: system.attributes.movement.speeds.turn
         mode: 5
         value: '150'
         priority: 20

--- a/packs/_source/starships/starship-features/medium/role-missile-boat.yml
+++ b/packs/_source/starships/starship-features/medium/role-missile-boat.yml
@@ -11,11 +11,11 @@ effects:
         mode: 2
         value: '1'
         priority: 1
-      - key: system.attributes.movement.space
+      - key: system.attributes.movement.speeds.space
         mode: 5
         value: '400'
         priority: 20
-      - key: system.attributes.movement.turn
+      - key: system.attributes.movement.speeds.turn
         mode: 5
         value: '250'
         priority: 20

--- a/packs/_source/starships/starship-features/medium/role-navigator.yml
+++ b/packs/_source/starships/starship-features/medium/role-navigator.yml
@@ -11,11 +11,11 @@ effects:
         mode: 2
         value: '1'
         priority: 1
-      - key: system.attributes.movement.space
+      - key: system.attributes.movement.speeds.space
         mode: 5
         value: '350'
         priority: 20
-      - key: system.attributes.movement.turn
+      - key: system.attributes.movement.speeds.turn
         mode: 5
         value: '200'
         priority: 20

--- a/packs/_source/starships/starship-features/medium/role-yacht.yml
+++ b/packs/_source/starships/starship-features/medium/role-yacht.yml
@@ -11,11 +11,11 @@ effects:
         mode: 2
         value: '1'
         priority: 1
-      - key: system.attributes.movement.space
+      - key: system.attributes.movement.speeds.space
         mode: 5
         value: '350'
         priority: 20
-      - key: system.attributes.movement.turn
+      - key: system.attributes.movement.speeds.turn
         mode: 5
         value: '200'
         priority: 20

--- a/packs/_source/starships/starship-features/small/role-attack-fighter.yml
+++ b/packs/_source/starships/starship-features/small/role-attack-fighter.yml
@@ -11,11 +11,11 @@ effects:
         mode: 2
         value: '1'
         priority: 1
-      - key: system.attributes.movement.space
+      - key: system.attributes.movement.speeds.space
         mode: 5
         value: '350'
         priority: 20
-      - key: system.attributes.movement.turn
+      - key: system.attributes.movement.speeds.turn
         mode: 5
         value: '100'
         priority: 20

--- a/packs/_source/starships/starship-features/small/role-bomber.yml
+++ b/packs/_source/starships/starship-features/small/role-bomber.yml
@@ -11,11 +11,11 @@ effects:
         mode: 2
         value: '1'
         priority: 1
-      - key: system.attributes.movement.space
+      - key: system.attributes.movement.speeds.space
         mode: 5
         value: '450'
         priority: 20
-      - key: system.attributes.movement.turn
+      - key: system.attributes.movement.speeds.turn
         mode: 5
         value: '200'
         priority: 20

--- a/packs/_source/starships/starship-features/small/role-scout.yml
+++ b/packs/_source/starships/starship-features/small/role-scout.yml
@@ -11,11 +11,11 @@ effects:
         mode: 2
         value: '1'
         priority: 1
-      - key: system.attributes.movement.space
+      - key: system.attributes.movement.speeds.space
         mode: 5
         value: '450'
         priority: 20
-      - key: system.attributes.movement.turn
+      - key: system.attributes.movement.speeds.turn
         mode: 5
         value: '200'
         priority: 20

--- a/packs/_source/starships/starship-features/small/role-scrambler.yml
+++ b/packs/_source/starships/starship-features/small/role-scrambler.yml
@@ -11,11 +11,11 @@ effects:
         mode: 2
         value: '1'
         priority: 1
-      - key: system.attributes.movement.space
+      - key: system.attributes.movement.speeds.space
         mode: 5
         value: '400'
         priority: 20
-      - key: system.attributes.movement.turn
+      - key: system.attributes.movement.speeds.turn
         mode: 5
         value: '150'
         priority: 20

--- a/packs/_source/starships/starship-features/small/role-shuttle.yml
+++ b/packs/_source/starships/starship-features/small/role-shuttle.yml
@@ -11,11 +11,11 @@ effects:
         mode: 2
         value: '1'
         priority: 1
-      - key: system.attributes.movement.space
+      - key: system.attributes.movement.speeds.space
         mode: 5
         value: '350'
         priority: 20
-      - key: system.attributes.movement.turn
+      - key: system.attributes.movement.speeds.turn
         mode: 5
         value: '100'
         priority: 20

--- a/packs/_source/starships/starship-features/small/role-superiority-fighter.yml
+++ b/packs/_source/starships/starship-features/small/role-superiority-fighter.yml
@@ -11,11 +11,11 @@ effects:
         mode: 2
         value: '1'
         priority: 1
-      - key: system.attributes.movement.space
+      - key: system.attributes.movement.speeds.space
         mode: 5
         value: '400'
         priority: 20
-      - key: system.attributes.movement.turn
+      - key: system.attributes.movement.speeds.turn
         mode: 5
         value: '150'
         priority: 20

--- a/packs/_source/starships/starship-features/tiny/role-droid.yml
+++ b/packs/_source/starships/starship-features/tiny/role-droid.yml
@@ -11,11 +11,11 @@ effects:
         mode: 2
         value: '1'
         priority: 1
-      - key: system.attributes.movement.space
+      - key: system.attributes.movement.speeds.space
         mode: 5
         value: '450'
         priority: 20
-      - key: system.attributes.movement.turn
+      - key: system.attributes.movement.speeds.turn
         mode: 5
         value: '200'
         priority: 20

--- a/packs/_source/starships/starship-features/tiny/role-munition.yml
+++ b/packs/_source/starships/starship-features/tiny/role-munition.yml
@@ -11,11 +11,11 @@ effects:
         mode: 2
         value: '1'
         priority: 1
-      - key: system.attributes.movement.space
+      - key: system.attributes.movement.speeds.space
         mode: 5
         value: '450'
         priority: 20
-      - key: system.attributes.movement.turn
+      - key: system.attributes.movement.speeds.turn
         mode: 5
         value: '200'
         priority: 20

--- a/packs/_source/starships/starship-features/tiny/role-predator.yml
+++ b/packs/_source/starships/starship-features/tiny/role-predator.yml
@@ -11,11 +11,11 @@ effects:
         mode: 2
         value: '1'
         priority: 1
-      - key: system.attributes.movement.space
+      - key: system.attributes.movement.speeds.space
         mode: 5
         value: '350'
         priority: 20
-      - key: system.attributes.movement.turn
+      - key: system.attributes.movement.speeds.turn
         mode: 5
         value: '100'
         priority: 20

--- a/packs/_source/starships/starship-features/tiny/role-probe.yml
+++ b/packs/_source/starships/starship-features/tiny/role-probe.yml
@@ -11,11 +11,11 @@ effects:
         mode: 2
         value: '1'
         priority: 1
-      - key: system.attributes.movement.space
+      - key: system.attributes.movement.speeds.space
         mode: 5
         value: '400'
         priority: 20
-      - key: system.attributes.movement.turn
+      - key: system.attributes.movement.speeds.turn
         mode: 5
         value: '150'
         priority: 20

--- a/packs/_source/starships/starship-features/tiny/role-satellite.yml
+++ b/packs/_source/starships/starship-features/tiny/role-satellite.yml
@@ -11,11 +11,11 @@ effects:
         mode: 2
         value: '1'
         priority: 1
-      - key: system.attributes.movement.space
+      - key: system.attributes.movement.speeds.space
         mode: 5
         value: '400'
         priority: 20
-      - key: system.attributes.movement.turn
+      - key: system.attributes.movement.speeds.turn
         mode: 5
         value: '150'
         priority: 20

--- a/packs/_source/starships/starship-features/tiny/role-worker.yml
+++ b/packs/_source/starships/starship-features/tiny/role-worker.yml
@@ -11,11 +11,11 @@ effects:
         mode: 2
         value: '1'
         priority: 1
-      - key: system.attributes.movement.space
+      - key: system.attributes.movement.speeds.space
         mode: 5
         value: '350'
         priority: 20
-      - key: system.attributes.movement.turn
+      - key: system.attributes.movement.speeds.turn
         mode: 5
         value: '100'
         priority: 20

--- a/packs/_source/starships/starship-modifications/engineering/interdiction-drive.yml
+++ b/packs/_source/starships/starship-modifications/engineering/interdiction-drive.yml
@@ -8,7 +8,7 @@ effects:
         mode: 2
         value: '-100'
         priority: 20
-      - key: system.attributes.movement.turn
+      - key: system.attributes.movement.speeds.turn
         mode: 2
         value: '50'
         priority: 20

--- a/packs/_source/starships/starship-modifications/engineering/invulnerability-drive.yml
+++ b/packs/_source/starships/starship-modifications/engineering/invulnerability-drive.yml
@@ -8,7 +8,7 @@ effects:
         mode: 1
         value: '0.5'
         priority: 20
-      - key: system.attributes.movement.turn
+      - key: system.attributes.movement.speeds.turn
         mode: 1
         value: '2'
         priority: 20

--- a/packs/_source/starships/starship-modifications/suite/external-docking-system.yml
+++ b/packs/_source/starships/starship-modifications/suite/external-docking-system.yml
@@ -8,7 +8,7 @@ effects:
         mode: 2
         value: '-50'
         priority: 20
-      - key: system.attributes.movement.turn
+      - key: system.attributes.movement.speeds.turn
         mode: 2
         value: '+50'
         priority: 20

--- a/packs/_source/starships/starship-modifications/universal/adaptive-ailerons.yml
+++ b/packs/_source/starships/starship-modifications/universal/adaptive-ailerons.yml
@@ -4,7 +4,7 @@ img: modules/sw5e-module/icons/packs/Starship%20Modifications/Universal.webp
 effects:
   - _id: yie6lRqE4olXJrK3
     changes:
-      - key: system.attributes.movement.turn
+      - key: system.attributes.movement.speeds.turn
         mode: 2
         value: '-100'
         priority: 20

--- a/packs/_source/starships/starship-modifications/universal/combat-thrusters-makeshift.yml
+++ b/packs/_source/starships/starship-modifications/universal/combat-thrusters-makeshift.yml
@@ -20,7 +20,7 @@ effects:
         mode: 2
         value: '-50'
         priority: 20
-      - key: system.attributes.movement.turn
+      - key: system.attributes.movement.speeds.turn
         mode: 2
         value: '-50'
         priority: 20

--- a/packs/_source/starships/starship-modifications/universal/combat-thrusters-mk-i.yml
+++ b/packs/_source/starships/starship-modifications/universal/combat-thrusters-mk-i.yml
@@ -16,7 +16,7 @@ effects:
     disabled: false
     _id: giD5qccvLQuASvKU
     changes:
-      - key: system.attributes.movement.turn
+      - key: system.attributes.movement.speeds.turn
         mode: 2
         value: '-50'
         priority: 20

--- a/packs/_source/starships/starship-modifications/universal/combat-thrusters-mk-ii.yml
+++ b/packs/_source/starships/starship-modifications/universal/combat-thrusters-mk-ii.yml
@@ -16,7 +16,7 @@ effects:
     disabled: false
     _id: P6dZIJK34mPaKIx2
     changes:
-      - key: system.attributes.movement.turn
+      - key: system.attributes.movement.speeds.turn
         mode: 2
         value: '-50'
         priority: 20

--- a/packs/_source/starships/starship-modifications/universal/combat-thrusters-mk-iii.yml
+++ b/packs/_source/starships/starship-modifications/universal/combat-thrusters-mk-iii.yml
@@ -16,7 +16,7 @@ effects:
     disabled: false
     _id: E8eundNrhx9KQ3nB
     changes:
-      - key: system.attributes.movement.turn
+      - key: system.attributes.movement.speeds.turn
         mode: 2
         value: '-50'
         priority: 20

--- a/packs/_source/starships/starship-modifications/universal/combat-thrusters-mk-iv.yml
+++ b/packs/_source/starships/starship-modifications/universal/combat-thrusters-mk-iv.yml
@@ -16,7 +16,7 @@ effects:
     disabled: false
     _id: L87yvpPxIucf8EL9
     changes:
-      - key: system.attributes.movement.turn
+      - key: system.attributes.movement.speeds.turn
         mode: 2
         value: '-50'
         priority: 20

--- a/packs/_source/starships/starship-modifications/universal/combat-thrusters-mk-v.yml
+++ b/packs/_source/starships/starship-modifications/universal/combat-thrusters-mk-v.yml
@@ -16,7 +16,7 @@ effects:
     disabled: false
     _id: lqi3U29eRfhiFoM9
     changes:
-      - key: system.attributes.movement.turn
+      - key: system.attributes.movement.speeds.turn
         mode: 2
         value: '-50'
         priority: 20

--- a/packs/_source/starships/starship-modifications/universal/sublight-drive-makeshift.yml
+++ b/packs/_source/starships/starship-modifications/universal/sublight-drive-makeshift.yml
@@ -16,7 +16,7 @@ effects:
     disabled: false
     _id: i5cGtdfpzIqeWq5F
     changes:
-      - key: system.attributes.movement.turn
+      - key: system.attributes.movement.speeds.turn
         mode: 2
         value: '50'
         priority: 20

--- a/scripts/data/item/maneuver.mjs
+++ b/scripts/data/item/maneuver.mjs
@@ -1,5 +1,9 @@
 import { getBestAbility } from "./../../utils.mjs";
 import {
+	adaptManeuverCardContext,
+	maneuverChatPropertyDescriptors
+} from "../../maneuver-card-data.mjs";
+import {
 	buildManeuverActivationTypes,
 	buildManeuverDescriptionSummary,
 	buildManeuverDurationUnits,
@@ -260,10 +264,11 @@ export default class ManeuverData extends ItemDataModel.mixin(ItemDescriptionTem
 	/** @inheritDoc */
 	async getCardData(enrichmentOptions = {}) {
 		const context = await super.getCardData(enrichmentOptions);
-		context.isManeuver = true;
-		context.subtitle = CONFIG.DND5E.superiority.types[this.type.value]?.label ?? "";
-		context.properties = [];
-		return context;
+		const typeLabel = CONFIG.DND5E.superiority.types[this.type.value]?.label ?? "";
+		return adaptManeuverCardContext(context, {
+			typeLabel,
+			extraProperties: this.chatProperties
+		});
 	}
 
 	/* -------------------------------------------- */
@@ -334,12 +339,10 @@ export default class ManeuverData extends ItemDataModel.mixin(ItemDescriptionTem
 
 	/**
 	 * Properties displayed in chat.
-	 * @type {string[]}
+	 * @type {object[]}
 	 */
 	get chatProperties() {
-		return [
-			...this.parent.labels.components?.tags ?? []
-		];
+		return maneuverChatPropertyDescriptors(this.parent.labels.components?.tags ?? []);
 	}
 
 	/* -------------------------------------------- */

--- a/scripts/maneuver-card-data.mjs
+++ b/scripts/maneuver-card-data.mjs
@@ -1,0 +1,44 @@
+/**
+ * Pure dnd5e 6.0.0 chat-card shape helpers for Maneuver items.
+ * Keep subtitle as an array and property entries as descriptors with a required type.
+ */
+
+/**
+ * @param {object} [context]
+ * @param {{ typeLabel?: string, extraProperties?: object[] }} [options]
+ * @returns {object}
+ */
+export function adaptManeuverCardContext(context={}, { typeLabel="", extraProperties=[] }={}) {
+	const next = context && typeof context === "object" ? context : {};
+	next.isManeuver = true;
+
+	const subtitle = Array.isArray(next.subtitle) ? [...next.subtitle] : [];
+	if ( typeLabel && !subtitle.includes(typeLabel) ) subtitle.push(typeLabel);
+	next.subtitle = subtitle;
+
+	const properties = Array.isArray(next.properties) ? [...next.properties] : [];
+	for ( const prop of extraProperties ) {
+		if ( prop && typeof prop === "object" && prop.type ) properties.push(prop);
+	}
+	next.properties = properties;
+	return next;
+}
+
+/**
+ * Map legacy string tags (or already-typed descriptors) to 6.0 card-property descriptors.
+ * @param {Array<string|object>} [tags]
+ * @returns {object[]}
+ */
+export function maneuverChatPropertyDescriptors(tags=[]) {
+	if ( !Array.isArray(tags) ) return [];
+	const out = [];
+	for ( const tag of tags ) {
+		if ( tag && typeof tag === "object" && tag.type ) {
+			out.push(tag);
+			continue;
+		}
+		if ( tag == null || tag === "" ) continue;
+		out.push({ type: "text", text: String(tag) });
+	}
+	return out;
+}

--- a/scripts/patch/starship-armor-class-config.mjs
+++ b/scripts/patch/starship-armor-class-config.mjs
@@ -48,10 +48,10 @@ export function patchStarshipArmorClassConfig() {
 	try {
 		libWrapper.register(getModuleId(), target, async function(wrapped, partId, context, options) {
 			context = await wrapped(partId, context, options);
-			if ( !Array.isArray(context?.calculationOptions) ) return context;
+			if ( !Array.isArray(context?.formulaOptions) ) return context;
 			const isStarship = isSw5eStarshipActor(this.document);
-			context.calculationOptions = filterArmorClassCalculationOptions(
-				context.calculationOptions,
+			context.formulaOptions = filterArmorClassCalculationOptions(
+				context.formulaOptions,
 				isStarship
 			);
 			return context;

--- a/scripts/patch/starship-movement.mjs
+++ b/scripts/patch/starship-movement.mjs
@@ -29,8 +29,8 @@ function wireStarshipSpaceMovementActionHandlers() {
 	if ( !actionConfig || !TokenDocument5e?.getMovementActionCostFunction ) return;
 
 	actionConfig.getAnimationOptions = token => {
-		const actorMovement = token?.actor?.system.attributes?.movement ?? {};
-		if ( !(type in actorMovement) || actorMovement[type] ) return {};
+		const speeds = token?.actor?.system.attributes?.movement?.speeds ?? {};
+		if ( !(type in speeds) || speeds[type] ) return {};
 		return { movementSpeed: CONFIG.Token.movement.defaultSpeed / 2 };
 	};
 	actionConfig.getCostFunction = (...args) => TokenDocument5e.getMovementActionCostFunction(type, ...args);
@@ -49,30 +49,28 @@ export function initializeStarshipMovementWrappers() {
 }
 
 /**
- * Vehicle actors need persisted `attributes.movement.space` / `.turn` for config + token ruler speed.
+ * Vehicle actors persist Space/Turn under dnd5e 6.0 `attributes.movement.speeds`.
+ * CONFIG.DND5E.movementTypes.space/turn is registered at init; ensure the Vehicle
+ * MappingField initialKeys include those types. Do not inject sibling FormulaFields.
  */
 export function addStarshipSpaceMovementSchemaField() {
 	try {
 		const movement = dnd5e?.dataModels?.actor?.VehicleData?.schema?.fields?.attributes?.fields?.movement;
 		if ( !movement?.fields ) return;
-
-		const FormulaField = dnd5e.dataModels.fields.FormulaField;
-		if ( !movement.fields.space ) {
-			movement.fields.space = new FormulaField({
-				deterministic: true,
-				label: "SW5E.MovementSpace",
-				speed: true
-			});
-		}
-		if ( !movement.fields.turn ) {
-			movement.fields.turn = new FormulaField({
-				deterministic: true,
-				label: "SW5E.MovementTurn",
-				speed: true
-			});
+		const speedsField = movement.fields.speeds;
+		if ( !speedsField ) return;
+		const keys = speedsField.initialKeys;
+		for ( const key of STARSHIP_MOVEMENT_TYPE_KEYS ) {
+			if ( Array.isArray(keys) ) {
+				if ( !keys.includes(key) ) keys.push(key);
+			} else if ( keys && typeof keys === "object" && !(key in keys) ) {
+				keys[key] = {
+					label: key === "space" ? "SW5E.MovementSpace" : "SW5E.MovementTurn"
+				};
+			}
 		}
 	} catch ( err ) {
-		console.warn("SW5E MODULE | Could not add starship movement fields to VehicleData schema.", err);
+		console.warn("SW5E MODULE | Could not add starship movement speeds to VehicleData schema.", err);
 	}
 }
 

--- a/scripts/patch/starship-prepare.mjs
+++ b/scripts/patch/starship-prepare.mjs
@@ -99,10 +99,13 @@ export function patchStarshipPrepare() {
 				if ( this.attributes?.movement && (typeof this.attributes.movement === "object") ) {
 					// Live values only: Role AE / underlying base → routing → Slowed.
 					// Do not persist routing or Slowed into Actor underlying movement.
-					this.attributes.movement.space = movement.space;
-					this.attributes.movement.turn = movement.turn;
-					this.attributes.movement.walk = 0;
-					this.attributes.movement.fly = 0;
+					const speeds = (this.attributes.movement.speeds && typeof this.attributes.movement.speeds === "object")
+						? this.attributes.movement.speeds
+						: (this.attributes.movement.speeds = {});
+					speeds.space = movement.space;
+					speeds.turn = movement.turn;
+					speeds.walk = 0;
+					speeds.fly = 0;
 					if ( movement.units ) this.attributes.movement.units = movement.units;
 				}
 				if ( liveActor && Array.isArray(movement.roleWarnings) && movement.roleWarnings.length ) {

--- a/scripts/patch/starship-sheet-core-context.mjs
+++ b/scripts/patch/starship-sheet-core-context.mjs
@@ -722,8 +722,8 @@ export function formatMovement(actor, legacySystem, runtime = null) {
 		};
 	}
 
-	const spaceSpeed = Number.isFinite(Number(actor.system?.attributes?.movement?.space))
-		? Number(actor.system.attributes.movement.space)
+	const spaceSpeed = Number.isFinite(Number(actor.system?.attributes?.movement?.speeds?.space))
+		? Number(actor.system.attributes.movement.speeds.space)
 		: null;
 	return {
 		primary: spaceSpeed != null ? `${spaceSpeed} ${units}` : "-",

--- a/scripts/starship-data.mjs
+++ b/scripts/starship-data.mjs
@@ -777,7 +777,9 @@ function getMovementBaseValue(value) {
 /** Canonical Actor paths for Role published movement (OVERRIDE Active Effects). */
 export const STARSHIP_ROLE_MOVEMENT_SPACE_KEY = "system.attributes.movement.speeds.space";
 export const STARSHIP_ROLE_MOVEMENT_TURN_KEY = "system.attributes.movement.speeds.turn";
-export const STARSHIP_ACTIVE_EFFECT_MODE_OVERRIDE = 5;
+/** Foundry 14.367 ActiveEffect change string types (BaseActiveEffect.#MODES_TO_TYPES). */
+export const STARSHIP_ACTIVE_EFFECT_TYPE_OVERRIDE = "override";
+export const STARSHIP_ACTIVE_EFFECT_TYPE_ADD = "add";
 
 /**
  * Read Space/Turn from the dnd5e 6.0 Actor movement structure (`movement.speeds`).
@@ -797,11 +799,71 @@ function normalizeMovementEffectKey(key) {
 	return String(key ?? "").trim();
 }
 
-function isCanonicalRoleMovementOverrideChange(change) {
+function getStarshipMovementChangeType(change) {
+	return String(change?.type ?? "").trim();
+}
+
+function collectApplicableMovementEffects(actor) {
+	if ( !actor ) return [];
+	if ( typeof actor.allApplicableEffects === "function" ) return [...actor.allApplicableEffects()];
+	return actor.appliedEffects ?? actor.effects?.contents ?? actor.effects ?? [];
+}
+
+/**
+ * True when a change is a Foundry 14 OVERRIDE on a canonical `movement.speeds` path.
+ * Compares string `type` only. Sibling keys are not canonical.
+ * @param {object} [change]
+ * @returns {boolean}
+ */
+export function isCanonicalRoleMovementOverrideChange(change) {
 	const key = normalizeMovementEffectKey(change?.key);
-	const mode = Number(change?.mode);
-	if ( mode !== STARSHIP_ACTIVE_EFFECT_MODE_OVERRIDE ) return false;
+	if ( getStarshipMovementChangeType(change) !== STARSHIP_ACTIVE_EFFECT_TYPE_OVERRIDE ) return false;
 	return key === STARSHIP_ROLE_MOVEMENT_SPACE_KEY || key === STARSHIP_ROLE_MOVEMENT_TURN_KEY;
+}
+
+function isCanonicalStarshipMovementAddChange(change) {
+	const key = normalizeMovementEffectKey(change?.key);
+	if ( getStarshipMovementChangeType(change) !== STARSHIP_ACTIVE_EFFECT_TYPE_ADD ) return false;
+	return key === STARSHIP_ROLE_MOVEMENT_SPACE_KEY || key === STARSHIP_ROLE_MOVEMENT_TURN_KEY;
+}
+
+function emptyMovementOverrideValues() {
+	return { space: null, turn: null, source: null, hasPublishedEffect: false };
+}
+
+function readOverrideValuesFromEffects(effects = []) {
+	let space = null;
+	let turn = null;
+	let source = null;
+	for ( const effect of effects ) {
+		if ( !effect || effect.disabled ) continue;
+		for ( const change of effect.changes ?? [] ) {
+			if ( !isCanonicalRoleMovementOverrideChange(change) ) continue;
+			const key = normalizeMovementEffectKey(change.key);
+			const value = toFiniteNumber(change.value, null);
+			if ( value === null ) continue;
+			if ( key === STARSHIP_ROLE_MOVEMENT_SPACE_KEY ) space = value;
+			if ( key === STARSHIP_ROLE_MOVEMENT_TURN_KEY ) turn = value;
+			source = effect.name ?? source;
+		}
+	}
+	return {
+		space,
+		turn,
+		source,
+		hasPublishedEffect: space !== null || turn !== null
+	};
+}
+
+/**
+ * Canonical OVERRIDE values from applicable Actor effects (transferred Role items and
+ * world-created actor AEs). Sibling keys are ignored.
+ * @param {object|null} actor
+ * @returns {{ space: number|null, turn: number|null, source: string|null, hasPublishedEffect: boolean }}
+ */
+export function getStarshipMovementOverrideValues(actor) {
+	if ( !actor ) return emptyMovementOverrideValues();
+	return readOverrideValuesFromEffects(collectApplicableMovementEffects(actor));
 }
 
 /**
@@ -815,19 +877,11 @@ export function getRolePublishedMovementFromItems(items = []) {
 	let source = null;
 	for ( const item of roles ) {
 		const effects = item.effects?.contents ?? item.effects ?? [];
-		for ( const effect of effects ) {
-			if ( effect?.disabled ) continue;
-			for ( const change of effect.changes ?? [] ) {
-				if ( !isCanonicalRoleMovementOverrideChange(change) ) continue;
-				const key = normalizeMovementEffectKey(change.key);
-				const value = toFiniteNumber(change.value, null);
-				if ( value === null ) continue;
-				if ( key === STARSHIP_ROLE_MOVEMENT_SPACE_KEY ) space = value;
-				if ( key === STARSHIP_ROLE_MOVEMENT_TURN_KEY ) turn = value;
-			}
-		}
-		if ( space !== null || turn !== null ) {
-			source = item.name ?? "Role";
+		const fromItem = readOverrideValuesFromEffects(effects);
+		if ( fromItem.space !== null ) space = fromItem.space;
+		if ( fromItem.turn !== null ) turn = fromItem.turn;
+		if ( fromItem.hasPublishedEffect ) {
+			source = item.name ?? fromItem.source ?? "Role";
 			break;
 		}
 	}
@@ -874,12 +928,15 @@ export function getStarshipRoleMovementValidationWarnings(items = [], sizeSystem
  * Resolve prepared combat movement base before routing/Slowed.
  *
  * Authority (no Size / Role-item-speed fallback; no soft recovery from live 0):
- * - Enabled Override controllers → published Role OVERRIDE values from item AEs
- * - Else underlying Actor `_source` movement (homebrew)
- * - Plus enabled Add-mode deltas on canonical paths (e.g. Combat Thrusters)
+ * - Enabled Override controllers → canonical OVERRIDE values from applicable effects
+ *   (Role transfer or world-created actor AEs on `movement.speeds.*`)
+ * - Else underlying Actor `_source.speeds` (homebrew)
+ * - Else flag-stored chassis baseline when an actor is present (not live sibling extras)
+ * - Plus enabled Add-type deltas on canonical paths (e.g. Combat Thrusters)
  *
  * Never use already Slowed/routed prepared live values as the base (prevents double Slowed
  * when sheet code re-calls derive after prepare wrote Slowed results).
+ * Live sibling extras from obsolete AE keys are not controllers.
  */
 function resolveStarshipMovementBase({
 	items = [],
@@ -889,22 +946,28 @@ function resolveStarshipMovementBase({
 	actor = null,
 	addDeltas = null
 } = {}) {
-	const published = getRolePublishedMovementFromItems(items);
+	const publishedFromItems = getRolePublishedMovementFromItems(items);
+	const publishedFromActor = actor ? getStarshipMovementOverrideValues(actor) : emptyMovementOverrideValues();
+	const published = publishedFromActor.hasPublishedEffect ? publishedFromActor : publishedFromItems;
 	const underlying = actor
 		? getStarshipUnderlyingMovement(actor)
 		: {
 			space: getMovementBaseValue(legacyMovement.space),
 			turn: getMovementBaseValue(legacyMovement.turn)
 		};
+	const flagMovement = actor?.flags?.sw5e?.legacyStarshipActor?.system?.attributes?.movement ?? {};
 	const deltas = addDeltas ?? (actor ? getStarshipMovementAddDeltas(actor) : { space: 0, turn: 0 });
 
 	const pick = (field) => {
 		const controlled = !!fieldControllers?.[field]?.controlled;
 		let base = null;
-		if ( controlled && published[field] !== null ) base = published[field];
+		if ( controlled && published[field] !== null && published[field] !== undefined ) base = published[field];
 		else if ( underlying[field] !== null && underlying[field] !== undefined ) base = underlying[field];
-		else base = readStarshipActorMovementSpeeds(liveMovement)[field];
-		if ( base === null ) base = getMovementBaseValue(legacyMovement?.[field]) ?? 0;
+		else if ( !actor ) base = readStarshipActorMovementSpeeds(liveMovement)[field];
+		if ( base === null ) {
+			if ( actor ) base = getMovementBaseValue(flagMovement?.[field]) ?? 0;
+			else base = getMovementBaseValue(legacyMovement?.[field]) ?? 0;
+		}
 		return base + (Number(deltas[field]) || 0);
 	};
 
@@ -928,23 +991,17 @@ function resolveStarshipMovementBase({
 	};
 }
 
-/** Foundry ActiveEffect mode Add. */
-const STARSHIP_ACTIVE_EFFECT_MODE_ADD = 2;
-
 /**
- * Sum enabled Add-mode deltas on canonical movement paths (not Override).
+ * Sum enabled Add-type deltas on canonical movement paths (not Override).
+ * Uses Foundry 14 string `type`; does not read a numeric mode property.
  */
 export function getStarshipMovementAddDeltas(actor) {
 	const deltas = { space: 0, turn: 0 };
 	if ( !actor ) return deltas;
-	const effects = typeof actor.allApplicableEffects === "function"
-		? [...actor.allApplicableEffects()]
-		: (actor.appliedEffects ?? actor.effects?.contents ?? actor.effects ?? []);
-	for ( const effect of effects ) {
+	for ( const effect of collectApplicableMovementEffects(actor) ) {
 		if ( !effect || effect.disabled ) continue;
 		for ( const change of effect.changes ?? [] ) {
-			const mode = Number(change?.mode);
-			if ( mode !== STARSHIP_ACTIVE_EFFECT_MODE_ADD ) continue;
+			if ( !isCanonicalStarshipMovementAddChange(change) ) continue;
 			const key = normalizeMovementEffectKey(change.key);
 			const value = toFiniteNumber(change.value, null);
 			if ( value === null ) continue;
@@ -979,9 +1036,7 @@ export function getStarshipMovementFieldControllers(actor, { includeDisabled = f
 	if ( !actor ) return result;
 
 	const byField = { space: new Map(), turn: new Map() };
-	const effects = typeof actor.allApplicableEffects === "function"
-		? [...actor.allApplicableEffects()]
-		: (actor.appliedEffects ?? actor.effects?.contents ?? actor.effects ?? []);
+	const effects = collectApplicableMovementEffects(actor);
 	for ( const effect of effects ) {
 		if ( !effect ) continue;
 		if ( !includeDisabled && effect.disabled ) continue;
@@ -1119,11 +1174,10 @@ export function resolveStarshipMovementSourceUpdate({
 
 /**
  * Underlying stored Actor movement (homebrew / editable source), not prepared live.
+ * Reads `_source.speeds` only. Does not treat live sibling extras as underlying.
  */
 export function getStarshipUnderlyingMovement(actor) {
-	const src = actor?._source?.system?.attributes?.movement
-		?? actor?.system?.attributes?.movement
-		?? {};
+	const src = actor?._source?.system?.attributes?.movement ?? {};
 	const speeds = readStarshipActorMovementSpeeds(src);
 	return {
 		space: speeds.space,

--- a/scripts/starship-data.mjs
+++ b/scripts/starship-data.mjs
@@ -775,9 +775,23 @@ function getMovementBaseValue(value) {
 }
 
 /** Canonical Actor paths for Role published movement (OVERRIDE Active Effects). */
-export const STARSHIP_ROLE_MOVEMENT_SPACE_KEY = "system.attributes.movement.space";
-export const STARSHIP_ROLE_MOVEMENT_TURN_KEY = "system.attributes.movement.turn";
+export const STARSHIP_ROLE_MOVEMENT_SPACE_KEY = "system.attributes.movement.speeds.space";
+export const STARSHIP_ROLE_MOVEMENT_TURN_KEY = "system.attributes.movement.speeds.turn";
 export const STARSHIP_ACTIVE_EFFECT_MODE_OVERRIDE = 5;
+
+/**
+ * Read Space/Turn from the dnd5e 6.0 Actor movement structure (`movement.speeds`).
+ * Does not read obsolete sibling `movement.space` / `movement.turn` keys.
+ * @param {object} [movement]
+ * @returns {{ space: number|null, turn: number|null }}
+ */
+export function readStarshipActorMovementSpeeds(movement={}) {
+	const speeds = movement?.speeds && typeof movement.speeds === "object" ? movement.speeds : {};
+	return {
+		space: toFiniteNumber(speeds.space, null),
+		turn: toFiniteNumber(speeds.turn, null)
+	};
+}
 
 function normalizeMovementEffectKey(key) {
 	return String(key ?? "").trim();
@@ -889,7 +903,7 @@ function resolveStarshipMovementBase({
 		let base = null;
 		if ( controlled && published[field] !== null ) base = published[field];
 		else if ( underlying[field] !== null && underlying[field] !== undefined ) base = underlying[field];
-		else base = getMovementBaseValue(liveMovement?.[field]);
+		else base = readStarshipActorMovementSpeeds(liveMovement)[field];
 		if ( base === null ) base = getMovementBaseValue(legacyMovement?.[field]) ?? 0;
 		return base + (Number(deltas[field]) || 0);
 	};
@@ -1047,43 +1061,53 @@ export function resolveStarshipMovementSourceUpdate({
 	fieldControllers = null
 } = {}) {
 	const movement = { ...(proposedMovement ?? {}) };
+	const speeds = {
+		...(movement.speeds && typeof movement.speeds === "object" ? movement.speeds : {})
+	};
 	const controllers = fieldControllers ?? { space: { controlled: false }, turn: { controlled: false } };
 	const blockedFields = [];
 	const savedFields = [];
 
 	if ( pendingKeys ) {
-		for ( const key of ["space", "turn", "walk", "fly", "units"] ) {
+		for ( const key of ["space", "turn", "walk", "fly"] ) {
 			if ( pendingKeys.has(key) ) continue;
-			delete movement[key];
+			delete speeds[key];
 		}
+		if ( !pendingKeys.has("units") ) delete movement.units;
 	}
 
 	for ( const key of ["walk", "fly"] ) {
-		if ( key in movement ) delete movement[key];
+		delete speeds[key];
+		delete movement[key];
 	}
 
 	for ( const key of ["space", "turn"] ) {
-		if ( !(key in movement) ) continue;
-		const next = toFiniteNumber(movement[key], null);
+		if ( !(key in speeds) ) continue;
+		const next = toFiniteNumber(speeds[key], null);
 		if ( next === null ) {
-			delete movement[key];
+			delete speeds[key];
 			continue;
 		}
 		const rounded = Math.max(0, Math.round(next));
-		movement[key] = rounded;
+		speeds[key] = rounded;
 		const prior = toFiniteNumber(underlying[key], null);
 		const changed = prior === null ? true : rounded !== Math.round(prior);
 		if ( !changed ) {
-			delete movement[key];
+			delete speeds[key];
 			continue;
 		}
 		if ( controllers[key]?.controlled ) {
-			delete movement[key];
+			delete speeds[key];
 			blockedFields.push(key);
 			continue;
 		}
 		savedFields.push(key);
 	}
+
+	delete movement.space;
+	delete movement.turn;
+	if ( Object.keys(speeds).length ) movement.speeds = speeds;
+	else delete movement.speeds;
 
 	return {
 		movement,
@@ -1100,9 +1124,10 @@ export function getStarshipUnderlyingMovement(actor) {
 	const src = actor?._source?.system?.attributes?.movement
 		?? actor?.system?.attributes?.movement
 		?? {};
+	const speeds = readStarshipActorMovementSpeeds(src);
 	return {
-		space: toFiniteNumber(src.space, null),
-		turn: toFiniteNumber(src.turn, null),
+		space: speeds.space,
+		turn: speeds.turn,
 		units: src.units ?? "ft"
 	};
 }

--- a/scripts/starship-movement-config.mjs
+++ b/scripts/starship-movement-config.mjs
@@ -6,6 +6,8 @@ import {
 } from "./starship-data.mjs";
 import { isSw5eStarshipActor, STARSHIP_MOVEMENT_TYPE_KEYS } from "./patch/starship-movement.mjs";
 
+const STARSHIP_SPEEDS_PATH_PREFIX = "system.attributes.movement.speeds.";
+const STARSHIP_UNITS_PATH = "system.attributes.movement.units";
 const STARSHIP_MOVEMENT_TYPE_SET = new Set(STARSHIP_MOVEMENT_TYPE_KEYS);
 const STARSHIP_BRIDGED_MOVEMENT_KEYS = Object.freeze(["space", "turn", "walk", "fly", "units"]);
 const STARSHIP_FIXED_ZERO_MOVEMENT_KEYS = Object.freeze(["walk", "fly"]);
@@ -35,7 +37,7 @@ function resolveMovementTypeKey(entry, index, orderedKeys, fields) {
 
 function ensureStarshipMovementEntryName(entry, key) {
 	if ( !entry || !key ) return;
-	const path = `system.attributes.movement.${key}`;
+	const path = key === "units" ? STARSHIP_UNITS_PATH : `${STARSHIP_SPEEDS_PATH_PREFIX}${key}`;
 	if ( !entry.name ) entry.name = path;
 	if ( entry.field && !entry.field.name ) entry.field.name = path;
 }
@@ -43,10 +45,12 @@ function ensureStarshipMovementEntryName(entry, key) {
 function getTrackedStarshipMovementKey(target) {
 	const path = target?.name;
 	if ( typeof path !== "string" ) return null;
-	const key = path.startsWith("system.attributes.movement.")
-		? path.slice("system.attributes.movement.".length)
-		: null;
-	return key && STARSHIP_BRIDGED_MOVEMENT_KEY_SET.has(key) ? key : null;
+	if ( path === STARSHIP_UNITS_PATH ) return "units";
+	if ( path.startsWith(STARSHIP_SPEEDS_PATH_PREFIX) ) {
+		const key = path.slice(STARSHIP_SPEEDS_PATH_PREFIX.length);
+		return key && STARSHIP_BRIDGED_MOVEMENT_KEY_SET.has(key) ? key : null;
+	}
+	return null;
 }
 
 function resetPendingStarshipMovementEdits(actor) {
@@ -176,6 +180,7 @@ function onStarshipMovementConfigPreUpdate(doc, changed) {
 
 	for ( const key of STARSHIP_FIXED_ZERO_MOVEMENT_KEYS ) {
 		if ( key in movement ) delete movement[key];
+		if ( movement.speeds && (key in movement.speeds) ) delete movement.speeds[key];
 	}
 
 	if ( resolved.warning ) {

--- a/scripts/starship-movement-config.mjs
+++ b/scripts/starship-movement-config.mjs
@@ -5,9 +5,13 @@ import {
 	resolveStarshipMovementSourceUpdate
 } from "./starship-data.mjs";
 import { isSw5eStarshipActor, STARSHIP_MOVEMENT_TYPE_KEYS } from "./patch/starship-movement.mjs";
+import {
+	STARSHIP_SPEEDS_PATH_PREFIX,
+	STARSHIP_UNITS_PATH,
+	filterNonStarshipMovementContext,
+	resolveMovementTypeKey
+} from "./starship-movement-context.mjs";
 
-const STARSHIP_SPEEDS_PATH_PREFIX = "system.attributes.movement.speeds.";
-const STARSHIP_UNITS_PATH = "system.attributes.movement.units";
 const STARSHIP_MOVEMENT_TYPE_SET = new Set(STARSHIP_MOVEMENT_TYPE_KEYS);
 const STARSHIP_BRIDGED_MOVEMENT_KEYS = Object.freeze(["space", "turn", "walk", "fly", "units"]);
 const STARSHIP_FIXED_ZERO_MOVEMENT_KEYS = Object.freeze(["walk", "fly"]);
@@ -19,20 +23,6 @@ const { MovementSensesConfig } = dnd5e.applications.shared;
 function localizeOrFallback(key, fallback) {
 	const localized = game.i18n.localize(key);
 	return localized && localized !== key ? localized : fallback;
-}
-
-/**
- * MovementSensesConfig builds `context.types` from `this.types` in order; `space` / `turn`
- * FormulaFields may lack `field.name`, so resolve the movement key by index or fields map.
- */
-function resolveMovementTypeKey(entry, index, orderedKeys, fields) {
-	const keyFromOrder = orderedKeys?.[index];
-	if ( keyFromOrder && fields?.[keyFromOrder] === entry.field ) return keyFromOrder;
-	if ( entry.field?.name ) return entry.field.name;
-	if ( entry.field && fields ) {
-		return Object.keys(fields).find(key => fields[key] === entry.field) ?? null;
-	}
-	return keyFromOrder ?? null;
 }
 
 function ensureStarshipMovementEntryName(entry, key) {
@@ -102,15 +92,6 @@ function applyStarshipMovementDisplayValues(actor, context, orderedKeys) {
 		const units = getStarshipDialogMovementValue(actor, "units");
 		if ( units !== undefined && units !== null && units !== "" ) context.data.units = units;
 	}
-	return context;
-}
-
-function filterNonStarshipMovementContext(context, orderedKeys) {
-	if ( !Array.isArray(context.types) ) return context;
-	context.types = context.types.filter((entry, index) => {
-		const key = resolveMovementTypeKey(entry, index, orderedKeys, context.fields);
-		return !key || !STARSHIP_MOVEMENT_TYPE_SET.has(key);
-	});
 	return context;
 }
 

--- a/scripts/starship-movement-context.mjs
+++ b/scripts/starship-movement-context.mjs
@@ -1,0 +1,69 @@
+import { STARSHIP_MOVEMENT_TYPE_KEYS } from "./patch/starship-movement.mjs";
+
+/** dnd5e 6.0 MovementSensesConfig field name prefix for MappingField speeds. */
+export const STARSHIP_SPEEDS_PATH_PREFIX = "system.attributes.movement.speeds.";
+export const STARSHIP_UNITS_PATH = "system.attributes.movement.units";
+
+const STARSHIP_MOVEMENT_TYPE_SET = new Set(STARSHIP_MOVEMENT_TYPE_KEYS);
+
+/**
+ * Resolve a 6.0 MovementSensesConfig `types[]` entry to a short movement key.
+ * Prefer `entry.name` (`system.attributes.movement.speeds.<key>`). Do not treat a
+ * shared MappingField model `field.name` as the movement type.
+ * @param {{ name?: string, field?: { name?: string } }} [entry]
+ * @param {number} index
+ * @param {string[]} [orderedKeys]
+ * @param {Record<string, unknown>} [fields]
+ * @returns {string|null}
+ */
+export function resolveMovementTypeKey(entry, index, orderedKeys, fields) {
+	const fromName = movementTypeKeyFromEntryName(entry?.name);
+	if ( fromName ) return fromName;
+
+	const keyFromOrder = orderedKeys?.[index];
+	if ( keyFromOrder && fields?.[keyFromOrder] === entry?.field ) return keyFromOrder;
+
+	const fieldName = entry?.field?.name;
+	if ( typeof fieldName === "string" && fieldName && !fieldName.includes(".") ) {
+		const fromFieldPath = movementTypeKeyFromEntryName(fieldName);
+		if ( fromFieldPath ) return fromFieldPath;
+		if ( STARSHIP_MOVEMENT_TYPE_SET.has(fieldName) || keyFromOrder === fieldName ) return fieldName;
+	}
+
+	if ( keyFromOrder ) return keyFromOrder;
+
+	if ( entry?.field && fields ) {
+		return Object.keys(fields).find(key => fields[key] === entry.field) ?? null;
+	}
+	return null;
+}
+
+/**
+ * @param {string} [name]
+ * @returns {string|null}
+ */
+export function movementTypeKeyFromEntryName(name) {
+	if ( typeof name !== "string" || !name ) return null;
+	if ( name === STARSHIP_UNITS_PATH ) return "units";
+	if ( name.startsWith(STARSHIP_SPEEDS_PATH_PREFIX) ) {
+		const key = name.slice(STARSHIP_SPEEDS_PATH_PREFIX.length);
+		return key || null;
+	}
+	return null;
+}
+
+/**
+ * Remove Space/Turn rows from a 6.0 MovementSensesConfig context.
+ * Mutates `context.types`. Does not prove rendering.
+ * @param {{ types?: object[], fields?: object }} context
+ * @param {string[]} [orderedKeys]
+ * @returns {object}
+ */
+export function filterNonStarshipMovementContext(context, orderedKeys) {
+	if ( !context || !Array.isArray(context.types) ) return context;
+	context.types = context.types.filter((entry, index) => {
+		const key = resolveMovementTypeKey(entry, index, orderedKeys, context.fields);
+		return !key || !STARSHIP_MOVEMENT_TYPE_SET.has(key);
+	});
+	return context;
+}

--- a/utils/test-maneuver-card-data.mjs
+++ b/utils/test-maneuver-card-data.mjs
@@ -1,0 +1,72 @@
+#!/usr/bin/env node
+/**
+ * Pure-logic tests for dnd5e 6.0.0 Maneuver chat-card subtitle/property shapes.
+ * Does not prove rendered chat HTML, sheets, or Foundry Item preparation.
+ */
+import assert from "node:assert/strict";
+import {
+	adaptManeuverCardContext,
+	maneuverChatPropertyDescriptors
+} from "../scripts/maneuver-card-data.mjs";
+
+let passed = 0;
+function test(name, fn) {
+	fn();
+	passed += 1;
+	console.log(`ok - ${name}`);
+}
+
+test("subtitle remains an array and keeps the SW5e type label", () => {
+	const context = adaptManeuverCardContext(
+		{ subtitle: ["Maneuver"], properties: [{ type: "text", text: "Item", identity: true }] },
+		{ typeLabel: "General" }
+	);
+	assert.equal(Array.isArray(context.subtitle), true);
+	assert.deepEqual(context.subtitle, ["Maneuver", "General"]);
+	assert.equal(context.isManeuver, true);
+});
+
+test("string subtitle is replaced with an array containing the SW5e label", () => {
+	const context = adaptManeuverCardContext(
+		{ subtitle: "General", properties: [] },
+		{ typeLabel: "General" }
+	);
+	assert.equal(Array.isArray(context.subtitle), true);
+	assert.deepEqual(context.subtitle, ["General"]);
+});
+
+test("superclass property descriptors are preserved", () => {
+	const superProp = { type: "text", text: "Maneuver", identity: true };
+	const context = adaptManeuverCardContext(
+		{ subtitle: ["Maneuver"], properties: [superProp] },
+		{ typeLabel: "Commander", extraProperties: [{ type: "text", text: "Concentration" }] }
+	);
+	assert.equal(context.properties[0], superProp);
+	assert.equal(context.properties[1].type, "text");
+	assert.equal(context.properties[1].text, "Concentration");
+});
+
+test("untyped extra properties are not appended", () => {
+	const context = adaptManeuverCardContext(
+		{ subtitle: [], properties: [] },
+		{ extraProperties: ["Concentration", { text: "no-type" }, { type: "text", text: "ok" }] }
+	);
+	assert.equal(context.properties.length, 1);
+	assert.equal(context.properties[0].type, "text");
+});
+
+test("chat property tags become typed descriptors", () => {
+	const props = maneuverChatPropertyDescriptors(["Concentration", "General"]);
+	assert.equal(props.every(p => p && typeof p === "object" && p.type), true);
+	assert.deepEqual(props, [
+		{ type: "text", text: "Concentration" },
+		{ type: "text", text: "General" }
+	]);
+});
+
+test("already-typed chat properties pass through", () => {
+	const existing = { type: "property", property: "concentration" };
+	assert.deepEqual(maneuverChatPropertyDescriptors([existing, ""]), [existing]);
+});
+
+console.log(`\n${passed} passed`);

--- a/utils/test-role-movement-active-effects.mjs
+++ b/utils/test-role-movement-active-effects.mjs
@@ -62,8 +62,8 @@ const MATRIX = {
 	}
 };
 
-const SPACE_KEY = "system.attributes.movement.space";
-const TURN_KEY = "system.attributes.movement.turn";
+const SPACE_KEY = "system.attributes.movement.speeds.space";
+const TURN_KEY = "system.attributes.movement.speeds.turn";
 const MODE_OVERRIDE = 5;
 
 let passed = 0;

--- a/utils/test-starship-armor-class-config.mjs
+++ b/utils/test-starship-armor-class-config.mjs
@@ -1,0 +1,60 @@
+#!/usr/bin/env node
+/**
+ * Pure-logic tests for starship vs non-starship Armor Class formulaOptions filtering.
+ * Does not prove ArmorClassConfig rendering or formula selection in Foundry.
+ */
+import assert from "node:assert/strict";
+import { filterArmorClassCalculationOptions } from "../scripts/patch/starship-armor-class-config.mjs";
+
+let passed = 0;
+function test(name, fn) {
+	fn();
+	passed += 1;
+	console.log(`ok - ${name}`);
+}
+
+const FORMULA_OPTIONS = [
+	{ value: "flat", label: "Flat" },
+	{ value: "natural", label: "Natural Armor" },
+	{ value: "default", label: "Equipped Armor" },
+	{ value: "unarmoredMonk", label: "Unarmored Defense (Monk)" },
+	{ value: "starship", label: "Starship" },
+	{ value: "custom", label: "Custom Formula" }
+];
+
+test("6.0 formulaOptions {value,label} input is accepted", () => {
+	const out = filterArmorClassCalculationOptions(FORMULA_OPTIONS, true);
+	assert.equal(Array.isArray(out), true);
+	assert.ok(out.some(e => e.value === "starship"));
+});
+
+test("starship retains intended formulas including starship", () => {
+	const values = filterArmorClassCalculationOptions(FORMULA_OPTIONS, true)
+		.filter(e => !e.rule)
+		.map(e => e.value);
+	assert.deepEqual(values, ["flat", "natural", "default", "starship", "custom"]);
+});
+
+test("non-starship drops starship-only formulas", () => {
+	const values = filterArmorClassCalculationOptions(FORMULA_OPTIONS, false)
+		.filter(e => !e.rule)
+		.map(e => e.value);
+	assert.equal(values.includes("starship"), false);
+	assert.ok(values.includes("unarmoredMonk"));
+	assert.ok(values.includes("default"));
+});
+
+test("unrelated option fields are preserved", () => {
+	const input = [{ value: "flat", label: "Flat", extra: 7 }];
+	const out = filterArmorClassCalculationOptions(input, true);
+	const flat = out.find(e => e.value === "flat");
+	assert.equal(flat.extra, 7);
+	assert.equal(flat.label, "Flat");
+});
+
+test("non-array input is returned unchanged", () => {
+	assert.equal(filterArmorClassCalculationOptions(null, true), null);
+	assert.deepEqual(filterArmorClassCalculationOptions({ value: "flat" }, false), { value: "flat" });
+});
+
+console.log(`\n${passed} passed`);

--- a/utils/test-starship-movement-ae-controllers.mjs
+++ b/utils/test-starship-movement-ae-controllers.mjs
@@ -1,0 +1,193 @@
+#!/usr/bin/env node
+/**
+ * Pure-logic tests: Foundry 14 string Active Effect `type`, obsolete-key rejection,
+ * and Space/Turn controller equivalence. Does not prove Foundry AE application.
+ */
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+	STARSHIP_ACTIVE_EFFECT_TYPE_ADD,
+	STARSHIP_ACTIVE_EFFECT_TYPE_OVERRIDE,
+	STARSHIP_ROLE_MOVEMENT_SPACE_KEY,
+	STARSHIP_ROLE_MOVEMENT_TURN_KEY,
+	deriveStarshipMovementData,
+	getRolePublishedMovementFromItems,
+	getStarshipMovementAddDeltas,
+	getStarshipMovementFieldControllers,
+	getStarshipMovementOverrideValues,
+	isCanonicalRoleMovementOverrideChange
+} from "../scripts/starship-data.mjs";
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const STARSHIP_DATA = path.join(ROOT, "scripts", "starship-data.mjs");
+
+let passed = 0;
+function test(name, fn) {
+	fn();
+	passed += 1;
+	console.log(`ok - ${name}`);
+}
+
+function mockActor({ effects=[], sourceMovement={ space: 320, turn: 250 }, flags=null }={}) {
+	const speeds = {
+		space: sourceMovement.space,
+		turn: sourceMovement.turn
+	};
+	return {
+		effects: { contents: effects },
+		flags: flags ?? {},
+		_source: { system: { attributes: { movement: { units: "ft", speeds: { ...speeds } } } } },
+		system: { attributes: { movement: { units: "ft", speeds: { ...speeds } } } }
+	};
+}
+
+function change({ key, type, value, priority=20, mode }={}) {
+	const entry = { key, type, value: String(value), priority };
+	if ( mode !== undefined ) entry.mode = mode;
+	return entry;
+}
+
+test("constants match Foundry 14.367 string types", () => {
+	assert.equal(STARSHIP_ACTIVE_EFFECT_TYPE_OVERRIDE, "override");
+	assert.equal(STARSHIP_ACTIVE_EFFECT_TYPE_ADD, "add");
+	assert.equal(STARSHIP_ROLE_MOVEMENT_SPACE_KEY, "system.attributes.movement.speeds.space");
+	assert.equal(STARSHIP_ROLE_MOVEMENT_TURN_KEY, "system.attributes.movement.speeds.turn");
+});
+
+test("supported OVERRIDE and ADD string types are handled; unrelated types ignored", () => {
+	assert.equal(isCanonicalRoleMovementOverrideChange(change({
+		key: STARSHIP_ROLE_MOVEMENT_SPACE_KEY, type: "override", value: 99
+	})), true);
+	assert.equal(isCanonicalRoleMovementOverrideChange(change({
+		key: STARSHIP_ROLE_MOVEMENT_SPACE_KEY, type: "add", value: 50
+	})), false);
+	assert.equal(isCanonicalRoleMovementOverrideChange(change({
+		key: STARSHIP_ROLE_MOVEMENT_SPACE_KEY, type: "upgrade", value: 99
+	})), false);
+	assert.equal(isCanonicalRoleMovementOverrideChange(change({
+		key: STARSHIP_ROLE_MOVEMENT_SPACE_KEY, mode: 5, value: 99
+	})), false);
+
+	const addActor = mockActor({
+		effects: [{
+			id: "add1",
+			name: "Combat Thrusters",
+			disabled: false,
+			changes: [change({ key: STARSHIP_ROLE_MOVEMENT_SPACE_KEY, type: "add", value: 50 })]
+		}]
+	});
+	assert.equal(getStarshipMovementAddDeltas(addActor).space, 50);
+	assert.equal(getStarshipMovementFieldControllers(addActor).space.controlled, false);
+});
+
+test("obsolete sibling keys are ignored even with string OVERRIDE", () => {
+	const obsolete = {
+		id: "role-old",
+		name: "Role: Attack Fighter",
+		disabled: false,
+		changes: [
+			change({ key: "system.attributes.movement.space", type: "override", value: 350 }),
+			change({ key: "system.attributes.movement.turn", type: "override", value: 100 })
+		]
+	};
+	const actor = mockActor({
+		effects: [obsolete],
+		sourceMovement: { space: 320, turn: 250 }
+	});
+	assert.equal(getStarshipMovementFieldControllers(actor).space.controlled, false);
+	assert.equal(getStarshipMovementFieldControllers(actor).turn.controlled, false);
+	assert.equal(getStarshipMovementOverrideValues(actor).hasPublishedEffect, false);
+	assert.equal(getRolePublishedMovementFromItems([{
+		name: "Role: Attack Fighter",
+		type: "feat",
+		effects: [obsolete],
+		system: { type: { subtype: "role" } }
+	}]).hasPublishedEffect, false);
+
+	const result = deriveStarshipMovementData({
+		items: [],
+		legacySystem: { attributes: { movement: { space: 350, turn: 100 } } },
+		liveMovement: { speeds: { space: 350, turn: 100 }, space: 350, turn: 100 },
+		actor,
+		fieldControllers: getStarshipMovementFieldControllers(actor)
+	});
+	assert.equal(result.space, 320);
+	assert.equal(result.turn, 250);
+});
+
+test("Space and Turn OVERRIDE from actor AE beat _source and restore when uncontrolled", () => {
+	const effect = {
+		id: "manual",
+		name: "VAL Manual Speeds AE",
+		disabled: false,
+		changes: [
+			change({ key: STARSHIP_ROLE_MOVEMENT_SPACE_KEY, type: "override", value: 99 }),
+			change({ key: STARSHIP_ROLE_MOVEMENT_TURN_KEY, type: "override", value: 11 })
+		]
+	};
+	const actor = mockActor({
+		effects: [effect],
+		sourceMovement: { space: 320, turn: 250 }
+	});
+	const controllers = getStarshipMovementFieldControllers(actor);
+	assert.equal(controllers.space.controlled, true);
+	assert.equal(controllers.turn.controlled, true);
+	const enabled = deriveStarshipMovementData({
+		items: [],
+		legacySystem: {},
+		liveMovement: { speeds: { space: 320, turn: 250 } },
+		actor,
+		fieldControllers: controllers
+	});
+	assert.equal(enabled.space, 99);
+	assert.equal(enabled.turn, 11);
+
+	const disabledActor = mockActor({
+		effects: [{ ...effect, disabled: true }],
+		sourceMovement: { space: 320, turn: 250 }
+	});
+	const restored = deriveStarshipMovementData({
+		items: [],
+		legacySystem: {},
+		liveMovement: { speeds: { space: 320, turn: 250 } },
+		actor: disabledActor,
+		fieldControllers: getStarshipMovementFieldControllers(disabledActor)
+	});
+	assert.equal(restored.space, 320);
+	assert.equal(restored.turn, 250);
+});
+
+test("numeric-only mode on canonical keys is not a controller", () => {
+	const actor = mockActor({
+		effects: [{
+			id: "legacy-mode",
+			name: "Numeric Mode Only",
+			disabled: false,
+			changes: [
+				{ key: STARSHIP_ROLE_MOVEMENT_SPACE_KEY, mode: 5, value: "99" },
+				{ key: STARSHIP_ROLE_MOVEMENT_TURN_KEY, mode: 5, value: "11" }
+			]
+		}],
+		sourceMovement: { space: 320, turn: 250 }
+	});
+	assert.equal(getStarshipMovementFieldControllers(actor).space.controlled, false);
+	const result = deriveStarshipMovementData({
+		items: [],
+		legacySystem: {},
+		liveMovement: { speeds: { space: 320, turn: 250 } },
+		actor,
+		fieldControllers: getStarshipMovementFieldControllers(actor)
+	});
+	assert.equal(result.space, 320);
+	assert.equal(result.turn, 250);
+});
+
+test("movement runtime source does not read numeric mode", () => {
+	const text = fs.readFileSync(STARSHIP_DATA, "utf8");
+	assert.equal(/Number\(\s*change\??\.mode\s*\)/.test(text), false);
+	assert.equal(/change\?\.mode/.test(text), false);
+});
+
+console.log(`\n${passed} passed`);

--- a/utils/test-starship-movement-pack-keys.mjs
+++ b/utils/test-starship-movement-pack-keys.mjs
@@ -1,0 +1,186 @@
+#!/usr/bin/env node
+/**
+ * Pack-source census: eligible Active Effect movement keys use dnd5e 6.0 speeds paths.
+ * Does not prove Foundry import, AE application, sheets, or token rulers.
+ */
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import yaml from "js-yaml";
+import {
+	STARSHIP_ROLE_MOVEMENT_SPACE_KEY,
+	STARSHIP_ROLE_MOVEMENT_TURN_KEY
+} from "../scripts/starship-data.mjs";
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const SRC = path.join(ROOT, "packs/_source");
+const FEATURES = path.join(SRC, "starships/starship-features");
+const OBSOLETE_SPACE = "system.attributes.movement.space";
+const OBSOLETE_TURN = "system.attributes.movement.turn";
+const CANONICAL_SPACE = "system.attributes.movement.speeds.space";
+const CANONICAL_TURN = "system.attributes.movement.speeds.turn";
+
+let passed = 0;
+function test(name, fn) {
+	fn();
+	passed += 1;
+	console.log(`ok - ${name}`);
+}
+
+function walkYaml(dir, acc=[]) {
+	for ( const entry of fs.readdirSync(dir, { withFileTypes: true }) ) {
+		const full = path.join(dir, entry.name);
+		if ( entry.isDirectory() ) walkYaml(full, acc);
+		else if ( /\.ya?ml$/i.test(entry.name) ) acc.push(full);
+	}
+	return acc;
+}
+
+function collectAeChanges(node, trail, out) {
+	if ( !node || typeof node !== "object" ) return;
+	if ( Array.isArray(node) ) {
+		node.forEach((value, index) => collectAeChanges(value, `${trail}[${index}]`, out));
+		return;
+	}
+	if ( Array.isArray(node.changes) ) {
+		for ( const change of node.changes ) {
+			out.push({
+				trail,
+				effectName: node.name ?? null,
+				effectId: node._id ?? null,
+				key: String(change?.key ?? ""),
+				mode: change?.mode ?? change?.type ?? null,
+				value: change?.value ?? null,
+				priority: change?.priority ?? null,
+				transfer: node.transfer ?? null,
+				disabled: node.disabled ?? null
+			});
+		}
+	}
+	for ( const [key, value] of Object.entries(node) ) {
+		if ( value && typeof value === "object" ) collectAeChanges(value, `${trail}.${key}`, out);
+	}
+}
+
+function loadDoc(rel) {
+	const full = path.join(ROOT, rel);
+	return yaml.load(fs.readFileSync(full, "utf8"));
+}
+
+const yamlFiles = walkYaml(SRC);
+const aeChanges = [];
+for ( const file of yamlFiles ) {
+	const doc = yaml.load(fs.readFileSync(file, "utf8"));
+	const found = [];
+	collectAeChanges(doc, path.relative(ROOT, file), found);
+	for ( const change of found ) {
+		aeChanges.push({ file: path.relative(ROOT, file), ...change });
+	}
+}
+
+test("runtime constants match canonical pack keys", () => {
+	assert.equal(STARSHIP_ROLE_MOVEMENT_SPACE_KEY, CANONICAL_SPACE);
+	assert.equal(STARSHIP_ROLE_MOVEMENT_TURN_KEY, CANONICAL_TURN);
+});
+
+test("no eligible pack AE change retains obsolete sibling keys", () => {
+	const leftover = aeChanges.filter(change => change.key === OBSOLETE_SPACE || change.key === OBSOLETE_TURN);
+	assert.deepEqual(leftover, []);
+});
+
+test("Role Worker preserves IDs, OVERRIDE mode, values, priority, transfer", () => {
+	const doc = loadDoc("packs/_source/starships/starship-features/tiny/role-worker.yml");
+	assert.equal(doc._id, "1Lx1A9P1GUA8hyTx");
+	assert.equal(doc.system.attributes.speed.space, 350);
+	assert.equal(doc.system.attributes.speed.turn, 100);
+	const effect = doc.effects[0];
+	assert.equal(effect._id, "qQTMHDrpIch61Q7C");
+	assert.equal(effect.transfer, true);
+	assert.equal(effect.disabled, false);
+	const space = effect.changes.find(change => change.key === CANONICAL_SPACE);
+	const turn = effect.changes.find(change => change.key === CANONICAL_TURN);
+	assert.equal(space.mode, 5);
+	assert.equal(turn.mode, 5);
+	assert.equal(String(space.value), "350");
+	assert.equal(String(turn.value), "100");
+	assert.equal(space.priority, 20);
+	assert.equal(turn.priority, 20);
+	assert.equal(effect.changes.find(change => change.key === "system.abilities.str.value")?.value, "1");
+});
+
+test("Combat Thrusters Mk I Turn ADD is canonical and otherwise unchanged", () => {
+	const doc = loadDoc("packs/_source/starships/starship-modifications/universal/combat-thrusters-mk-i.yml");
+	assert.equal(doc._id, "X6aGTz0DRzG9FoIQ");
+	const effect = doc.effects[0];
+	assert.equal(effect._id, "giD5qccvLQuASvKU");
+	assert.equal(effect.changes.length, 1);
+	assert.equal(effect.changes[0].key, CANONICAL_TURN);
+	assert.equal(effect.changes[0].mode, 2);
+	assert.equal(String(effect.changes[0].value), "-50");
+	assert.equal(effect.changes[0].priority, 20);
+	assert.equal(effect.transfer, true);
+	assert.equal(effect.disabled, false);
+});
+
+test("Overload Systems Turn key is canonical; fly sibling is unchanged", () => {
+	const doc = loadDoc("packs/_source/deployments/operator/deployment-features/overload-systems.yml");
+	assert.equal(doc._id, "2GMuH7TIypF8O3bB");
+	const effect = doc.effects[0];
+	assert.equal(effect._id, "Xafum7u479aJ6zZA");
+	assert.equal(effect.changes[0].key, "system.attributes.movement.fly");
+	assert.equal(effect.changes[0].mode, 1);
+	assert.equal(String(effect.changes[0].value), ".5");
+	assert.equal(effect.changes[1].key, CANONICAL_TURN);
+	assert.equal(effect.changes[1].mode, 1);
+	assert.equal(String(effect.changes[1].value), "2");
+	assert.equal(effect.changes[1].priority, 20);
+	assert.equal(effect.transfer, false);
+});
+
+test("Drake delta-7 embedded Adaptive Ailerons Turn key is canonical; value preserved", () => {
+	const doc = loadDoc("packs/_source/drakes-shipyard/delta-7-aethersprite-class-light-interceptor-modified.yml");
+	assert.equal(doc._id, "FbzPxDn1FfeRvDym");
+	const item = (doc.items ?? []).find(entry => entry.name === "Adaptive Ailerons");
+	assert.ok(item);
+	const effect = (item.effects ?? []).find(entry => entry._id === "yie6lRqE4olXJrK3");
+	assert.ok(effect);
+	const turn = effect.changes.find(change => String(change.key).includes("movement"));
+	assert.equal(turn.key, CANONICAL_TURN);
+	assert.equal(turn.mode, 2);
+	assert.equal(String(turn.value), "+100");
+	assert.equal(turn.priority, 20);
+});
+
+test("Role YAML files publish canonical Space and Turn OVERRIDE keys", () => {
+	const sizeFolders = new Set(["tiny", "small", "medium", "large", "huge", "gargantuan"]);
+	const roleFiles = walkYaml(FEATURES).filter(file => {
+		const base = path.basename(file);
+		const size = path.basename(path.dirname(file));
+		return sizeFolders.has(size) && /^role-[^.]+\.yml$/i.test(base) && !base.includes("specialization") && !base.includes("mastery");
+	});
+	assert.equal(roleFiles.length, 36);
+	for ( const file of roleFiles ) {
+		const doc = yaml.load(fs.readFileSync(file, "utf8"));
+		const changes = doc.effects?.[0]?.changes ?? [];
+		assert.ok(changes.some(change => change.key === CANONICAL_SPACE), `${path.basename(file)} missing canonical space`);
+		assert.ok(changes.some(change => change.key === CANONICAL_TURN), `${path.basename(file)} missing canonical turn`);
+	}
+});
+
+test("Role attributes.speed metadata is not treated as an AE key defect", () => {
+	const doc = loadDoc("packs/_source/starships/starship-features/tiny/role-worker.yml");
+	assert.equal(typeof doc.system.attributes.speed.space, "number");
+	assert.equal(typeof doc.system.attributes.speed.turn, "number");
+	const speedHits = aeChanges.filter(change => change.file.includes("role-worker.yml")
+		&& (change.key === "space" || change.key === "turn"));
+	assert.deepEqual(speedHits, []);
+});
+
+test("prose and fly keys are not classified as obsolete sibling movement AE keys", () => {
+	const fly = aeChanges.filter(change => change.key === "system.attributes.movement.fly");
+	assert.ok(fly.length > 0, "expected remaining fly AE keys outside this remediation");
+	assert.equal(fly.some(change => change.key === OBSOLETE_SPACE || change.key === OBSOLETE_TURN), false);
+});
+
+console.log(`\n${passed} passed`);

--- a/utils/test-starship-movement-rules.mjs
+++ b/utils/test-starship-movement-rules.mjs
@@ -43,8 +43,8 @@ function roleItem({
 			);
 		} else {
 			changes.push(
-				{ key: "system.attributes.movement.space", mode, value: String(space), priority: 20 },
-				{ key: "system.attributes.movement.turn", mode, value: String(turn), priority: 20 }
+				{ key: "system.attributes.movement.speeds.space", mode, value: String(space), priority: 20 },
+				{ key: "system.attributes.movement.speeds.turn", mode, value: String(turn), priority: 20 }
 			);
 		}
 	}
@@ -79,10 +79,19 @@ function legacySystem({ routing="none" }={}) {
 }
 
 function mockActor({ effects=[], sourceMovement={} }={}) {
+	const movement = sourceMovement.speeds
+		? { units: sourceMovement.units ?? "ft", ...sourceMovement, speeds: { ...sourceMovement.speeds } }
+		: {
+			units: sourceMovement.units ?? "ft",
+			speeds: {
+				space: sourceMovement.space,
+				turn: sourceMovement.turn
+			}
+		};
 	return {
 		effects: { contents: effects },
-		_source: { system: { attributes: { movement: { ...sourceMovement } } } },
-		system: { attributes: { movement: { ...sourceMovement } } }
+		_source: { system: { attributes: { movement: { ...movement, speeds: { ...movement.speeds } } } } },
+		system: { attributes: { movement: { ...movement, speeds: { ...movement.speeds } } } }
 	};
 }
 
@@ -105,8 +114,8 @@ function overrideEffect({
 			{ key: "attributes.movement.turning", mode: 2, value: String(turn) }
 		);
 	} else {
-		if ( includeSpace ) changes.push({ key: "system.attributes.movement.space", mode, value: String(space) });
-		if ( includeTurn ) changes.push({ key: "system.attributes.movement.turn", mode, value: String(turn) });
+		if ( includeSpace ) changes.push({ key: "system.attributes.movement.speeds.space", mode, value: String(space) });
+		if ( includeTurn ) changes.push({ key: "system.attributes.movement.speeds.turn", mode, value: String(turn) });
 	}
 	return { id, name, disabled, changes };
 }
@@ -115,7 +124,7 @@ test("1. No Role, underlying present — Size does not alter", () => {
 	const result = deriveStarshipMovementData({
 		items: [],
 		legacySystem: legacySystem(),
-		liveMovement: { space: 120, turn: 80 },
+		liveMovement: { speeds: { space: 120, turn: 80 } },
 		sizeSystem: sizeSystem({ baseSpaceSpeed: 300, baseTurnSpeed: 250 })
 	});
 	assert.equal(result.space, 120);
@@ -127,7 +136,7 @@ test("2. No Role, underlying zero — Size does not replace zero", () => {
 	const result = deriveStarshipMovementData({
 		items: [],
 		legacySystem: legacySystem(),
-		liveMovement: { space: 0, turn: 0 },
+		liveMovement: { speeds: { space: 0, turn: 0 } },
 		sizeSystem: sizeSystem({ baseSpaceSpeed: 300, baseTurnSpeed: 250 })
 	});
 	assert.equal(result.space, 0);
@@ -145,7 +154,7 @@ test("3. Disabled Role movement effect — underlying live; Size does not restor
 	const result = deriveStarshipMovementData({
 		items: [roleItem({ space: 350, turn: 100 })],
 		legacySystem: legacySystem(),
-		liveMovement: { space: 40, turn: 30 },
+		liveMovement: { speeds: { space: 40, turn: 30 } },
 		sizeSystem: sizeSystem({ baseSpaceSpeed: 300, baseTurnSpeed: 250 }),
 		actor
 	});
@@ -154,7 +163,7 @@ test("3. Disabled Role movement effect — underlying live; Size does not restor
 
 	const resolved = resolveStarshipMovementSourceUpdate({
 		underlying: { space: 40, turn: 30 },
-		proposedMovement: { space: 55, turn: 44 },
+		proposedMovement: { speeds: { space: 55, turn: 44 } },
 		pendingKeys: new Set(["space", "turn"]),
 		fieldControllers: controllers
 	});
@@ -167,7 +176,7 @@ test("4. Deleted Role movement effect — underlying editable; no Size fallback"
 	const result = deriveStarshipMovementData({
 		items: [],
 		legacySystem: legacySystem(),
-		liveMovement: { space: 111, turn: 222 },
+		liveMovement: { speeds: { space: 111, turn: 222 } },
 		sizeSystem: sizeSystem({ baseSpaceSpeed: 300, baseTurnSpeed: 250 }),
 		fieldControllers: controllers
 	});
@@ -176,7 +185,7 @@ test("4. Deleted Role movement effect — underlying editable; no Size fallback"
 
 	const resolved = resolveStarshipMovementSourceUpdate({
 		underlying: { space: 111, turn: 222 },
-		proposedMovement: { space: 150, turn: 160 },
+		proposedMovement: { speeds: { space: 150, turn: 160 } },
 		pendingKeys: new Set(["space", "turn"]),
 		fieldControllers: controllers
 	});
@@ -193,7 +202,7 @@ test("5. Malformed Role effect — underlying authoritative; no Size conceal", (
 	const result = deriveStarshipMovementData({
 		items: [roleItem({ space: 350, turn: 100, badKeys: true })],
 		legacySystem: legacySystem(),
-		liveMovement: { space: 25, turn: 15 },
+		liveMovement: { speeds: { space: 25, turn: 15 } },
 		sizeSystem: sizeSystem({ baseSpaceSpeed: 300, baseTurnSpeed: 250 }),
 		fieldControllers: controllers
 	});
@@ -214,7 +223,7 @@ test("6. Valid Role Override — live AE values; Size does not independently aff
 	const result = deriveStarshipMovementData({
 		items,
 		legacySystem: legacySystem({ routing: "engines" }),
-		liveMovement: { space: 200, turn: 500 },
+		liveMovement: { speeds: { space: 200, turn: 500 } },
 		sizeSystem: sizeSystem({ baseSpaceSpeed: 999, baseTurnSpeed: 888 }),
 		fieldControllers: controllers,
 		slowedLevel: 1
@@ -232,7 +241,7 @@ test("7. Explicit zero with valid effect disabled — zero remains; no fallback"
 	const result = deriveStarshipMovementData({
 		items: [roleItem({ space: 350, turn: 100 })],
 		legacySystem: legacySystem(),
-		liveMovement: { space: 0, turn: 0 },
+		liveMovement: { speeds: { space: 0, turn: 0 } },
 		sizeSystem: sizeSystem({ baseSpaceSpeed: 300, baseTurnSpeed: 250 }),
 		actor
 	});
@@ -248,7 +257,7 @@ test("8. Role/Size mismatch soft warning — Size does not substitute speed", ()
 	const result = deriveStarshipMovementData({
 		items,
 		legacySystem: legacySystem(),
-		liveMovement: { space: 200, turn: 500 },
+		liveMovement: { speeds: { space: 200, turn: 500 } },
 		sizeSystem: sizeSystem({ identifier: "small", baseSpaceSpeed: 300, baseTurnSpeed: 250 }),
 		fieldControllers: getStarshipMovementFieldControllers(mockActor({
 			effects: [overrideEffect({ name: "Role: Warship", space: 200, turn: 500 })]
@@ -260,7 +269,7 @@ test("8. Role/Size mismatch soft warning — Size does not substitute speed", ()
 
 test("9. Size change alone does not change movement", () => {
 	const items = [];
-	const live = { space: 90, turn: 70 };
+	const live = { speeds: { space: 90, turn: 70 } };
 	const a = deriveStarshipMovementData({
 		items,
 		legacySystem: legacySystem(),
@@ -282,7 +291,7 @@ test("No soft recovery when published OVERRIDE exists but live is zero", () => {
 	const result = deriveStarshipMovementData({
 		items: [roleItem({ space: 200, turn: 500 })],
 		legacySystem: legacySystem(),
-		liveMovement: { space: 0, turn: 0 },
+		liveMovement: { speeds: { space: 0, turn: 0 } },
 		sizeSystem: sizeSystem()
 	});
 	assert.equal(result.space, 0);
@@ -293,7 +302,7 @@ test("No Role item attributes.speed runtime fallback when AE absent", () => {
 	const result = deriveStarshipMovementData({
 		items: [roleItem({ space: 350, turn: 100, withEffect: false })],
 		legacySystem: legacySystem(),
-		liveMovement: { space: 0, turn: 0 },
+		liveMovement: { speeds: { space: 0, turn: 0 } },
 		sizeSystem: sizeSystem({ baseSpaceSpeed: 300, baseTurnSpeed: 250 })
 	});
 	assert.equal(result.space, 0);
@@ -306,7 +315,7 @@ test("Controlled edit warns; does not save; no movementOverrides", () => {
 	}));
 	const resolved = resolveStarshipMovementSourceUpdate({
 		underlying: { space: 50, turn: 40 },
-		proposedMovement: { space: 999, turn: 888 },
+		proposedMovement: { speeds: { space: 999, turn: 888 } },
 		pendingKeys: new Set(["space", "turn"]),
 		fieldControllers: controllers
 	});
@@ -321,13 +330,13 @@ test("Partial control: Space Override, Turn free", () => {
 	}));
 	const resolved = resolveStarshipMovementSourceUpdate({
 		underlying: { space: 50, turn: 40 },
-		proposedMovement: { space: 999, turn: 120 },
+		proposedMovement: { speeds: { space: 999, turn: 120 } },
 		pendingKeys: new Set(["space", "turn"]),
 		fieldControllers: controllers
 	});
 	assert.deepEqual(resolved.blockedFields, ["space"]);
 	assert.deepEqual(resolved.savedFields, ["turn"]);
-	assert.equal(resolved.movement.turn, 120);
+	assert.equal(resolved.movement.speeds.turn, 120);
 });
 
 test("Add-mode / ability-only do not control base", () => {
@@ -352,7 +361,7 @@ test("Duplicate Override effects: ambiguous soft warning", () => {
 			roleItem({ name: "Role: B", space: 450, turn: 200 })
 		],
 		legacySystem: legacySystem(),
-		liveMovement: { space: 350, turn: 100 },
+		liveMovement: { speeds: { space: 350, turn: 100 } },
 		fieldControllers: controllers
 	});
 	assert.ok(result.roleWarnings.some(w => w.code === "duplicate-movement-override-space"));
@@ -364,13 +373,13 @@ test("Ability / tier do not alter Role movement", () => {
 	const a = deriveStarshipMovementData({
 		items,
 		legacySystem: legacySystem(),
-		liveMovement: { space: 350, turn: 100 },
+		liveMovement: { speeds: { space: 350, turn: 100 } },
 		liveAbilities: { str: { value: 3 }, con: { value: 30 } }
 	});
 	const b = deriveStarshipMovementData({
 		items,
 		legacySystem: legacySystem(),
-		liveMovement: { space: 350, turn: 100 },
+		liveMovement: { speeds: { space: 350, turn: 100 } },
 		liveAbilities: { str: { value: 30 }, con: { value: 3 } }
 	});
 	assert.equal(a.space, b.space);
@@ -387,7 +396,7 @@ test("Travel not mutated by derive", () => {
 	deriveStarshipMovementData({
 		items: [roleItem()],
 		legacySystem: legacy,
-		liveMovement: { space: 350, turn: 100 }
+		liveMovement: { speeds: { space: 350, turn: 100 } }
 	});
 	assert.equal(legacy.attributes.travel.speeds.air, "12");
 	assert.equal(legacy.attributes.travel.paces.air, "fast");
@@ -397,7 +406,7 @@ test("Routing ×2 / ×0.5 on live base once", () => {
 	const engines = deriveStarshipMovementData({
 		items: [roleItem({ space: 350, turn: 100 })],
 		legacySystem: legacySystem({ routing: "engines" }),
-		liveMovement: { space: 350, turn: 100 }
+		liveMovement: { speeds: { space: 350, turn: 100 } }
 	});
 	assert.equal(engines.space, 700);
 	assert.equal(engines.turn, 100);
@@ -405,7 +414,7 @@ test("Routing ×2 / ×0.5 on live base once", () => {
 	const shields = deriveStarshipMovementData({
 		items: [roleItem({ space: 350, turn: 100 })],
 		legacySystem: legacySystem({ routing: "shields" }),
-		liveMovement: { space: 350, turn: 100 }
+		liveMovement: { speeds: { space: 350, turn: 100 } }
 	});
 	assert.equal(shields.space, 175);
 });
@@ -428,7 +437,7 @@ test("A. Slowed exact mapping base 200/500", () => {
 			items,
 			actor,
 			legacySystem: legacySystem(),
-			liveMovement: { space: 999, turn: 999 },
+			liveMovement: { speeds: { space: 999, turn: 999 } },
 			slowedLevel: Number(level)
 		});
 		assert.equal(result.space, space, `level ${level} space`);
@@ -485,12 +494,12 @@ test("C. Level transitions never compound prior Slowed output", () => {
 			items,
 			actor,
 			legacySystem: legacySystem(),
-			liveMovement: prior ?? { space: 200, turn: 500 },
+			liveMovement: prior ?? { speeds: { space: 200, turn: 500 } },
 			slowedLevel: level
 		});
 		assert.equal(result.space, expect[level][0], `transition→${level} space`);
 		assert.equal(result.turn, expect[level][1], `transition→${level} turn`);
-		prior = { space: result.space, turn: result.turn };
+		prior = { speeds: { space: result.space, turn: result.turn } };
 	}
 });
 
@@ -500,7 +509,7 @@ test("D. Repeated derive at same level does not compound", () => {
 		effects: [overrideEffect({ name: "Role: Warship", space: 200, turn: 500 })],
 		sourceMovement: { space: 10, turn: 10 }
 	});
-	let live = { space: 200, turn: 500 };
+	let live = { speeds: { space: 200, turn: 500 } };
 	for ( let i = 0; i < 5; i++ ) {
 		const result = deriveStarshipMovementData({
 			items,
@@ -511,7 +520,7 @@ test("D. Repeated derive at same level does not compound", () => {
 		});
 		assert.equal(result.space, 50);
 		assert.equal(result.turn, 350);
-		live = { space: result.space, turn: result.turn };
+		live = { speeds: { space: result.space, turn: result.turn } };
 	}
 });
 
@@ -577,8 +586,8 @@ test("G. Removal / inactive restores routed Role base; underlying unchanged", ()
 	});
 	assert.equal(cleared.space, 400);
 	assert.equal(cleared.turn, 500);
-	assert.equal(actor._source.system.attributes.movement.space, 40);
-	assert.equal(actor._source.system.attributes.movement.turn, 30);
+	assert.equal(actor._source.system.attributes.movement.speeds.space, 40);
+	assert.equal(actor._source.system.attributes.movement.speeds.turn, 30);
 });
 
 test("Stored travel is preserved under Slowed fill", () => {

--- a/utils/test-starship-movement-rules.mjs
+++ b/utils/test-starship-movement-rules.mjs
@@ -29,22 +29,22 @@ function roleItem({
 	requirements="Small Starship",
 	withEffect=true,
 	disabled=false,
-	mode=5,
+	type="override",
 	badKeys=false
 }={}) {
 	const changes = [
-		{ key: "system.abilities.con.value", mode: 2, value: "1", priority: 1 }
+		{ key: "system.abilities.con.value", type: "add", value: "1", priority: 1 }
 	];
 	if ( withEffect ) {
 		if ( badKeys ) {
 			changes.push(
-				{ key: "attributes.movement.space", mode: 2, value: String(space), priority: 20 },
-				{ key: "attributes.movement.turning", mode: 2, value: String(turn), priority: 20 }
+				{ key: "attributes.movement.space", type: "add", value: String(space), priority: 20 },
+				{ key: "attributes.movement.turning", type: "add", value: String(turn), priority: 20 }
 			);
 		} else {
 			changes.push(
-				{ key: "system.attributes.movement.speeds.space", mode, value: String(space), priority: 20 },
-				{ key: "system.attributes.movement.speeds.turn", mode, value: String(turn), priority: 20 }
+				{ key: "system.attributes.movement.speeds.space", type, value: String(space), priority: 20 },
+				{ key: "system.attributes.movement.speeds.turn", type, value: String(turn), priority: 20 }
 			);
 		}
 	}
@@ -107,15 +107,15 @@ function overrideEffect({
 	malformed=false
 }={}) {
 	const changes = [];
-	const mode = addMode ? 2 : 5;
+	const type = addMode ? "add" : "override";
 	if ( malformed ) {
 		changes.push(
-			{ key: "attributes.movement.space", mode: 2, value: String(space) },
-			{ key: "attributes.movement.turning", mode: 2, value: String(turn) }
+			{ key: "attributes.movement.space", type: "add", value: String(space) },
+			{ key: "attributes.movement.turning", type: "add", value: String(turn) }
 		);
 	} else {
-		if ( includeSpace ) changes.push({ key: "system.attributes.movement.speeds.space", mode, value: String(space) });
-		if ( includeTurn ) changes.push({ key: "system.attributes.movement.speeds.turn", mode, value: String(turn) });
+		if ( includeSpace ) changes.push({ key: "system.attributes.movement.speeds.space", type, value: String(space) });
+		if ( includeTurn ) changes.push({ key: "system.attributes.movement.speeds.turn", type, value: String(turn) });
 	}
 	return { id, name, disabled, changes };
 }

--- a/utils/test-starship-movement-senses-context.mjs
+++ b/utils/test-starship-movement-senses-context.mjs
@@ -1,0 +1,89 @@
+#!/usr/bin/env node
+/**
+ * Pure-logic tests: dnd5e 6.0 MovementSensesConfig context filtering.
+ * Models the 6.0 `context.types` shape. Does not prove Foundry rendering.
+ */
+import assert from "node:assert/strict";
+import {
+	filterNonStarshipMovementContext,
+	resolveMovementTypeKey
+} from "../scripts/starship-movement-context.mjs";
+
+let passed = 0;
+function test(name, fn) {
+	fn();
+	passed += 1;
+	console.log(`ok - ${name}`);
+}
+
+const ORDERED_KEYS = ["walk", "burrow", "climb", "fly", "jump", "swim", "space", "turn"];
+const STOCK_KEYS = ["walk", "burrow", "climb", "fly", "jump", "swim"];
+
+function sixContext(extraEntry=null) {
+	const sharedModel = { name: "value" };
+	const fields = {
+		bonus: { name: "bonus" },
+		multiplier: { name: "multiplier" },
+		speeds: { model: sharedModel },
+		units: { name: "units" },
+		hover: { name: "hover" }
+	};
+	const types = ORDERED_KEYS.map(key => ({
+		field: sharedModel,
+		label: key,
+		name: `system.attributes.movement.speeds.${key}`,
+		value: key === "walk" ? 30 : 0,
+		placeholder: ""
+	}));
+	if ( extraEntry ) types.push(extraEntry);
+	return { fields, types, extras: [{ field: fields.bonus, name: "system.attributes.movement.bonus" }] };
+}
+
+test("6.0 shared FormulaField does not resolve via field.name value", () => {
+	const context = sixContext();
+	const spaceIndex = ORDERED_KEYS.indexOf("space");
+	const key = resolveMovementTypeKey(context.types[spaceIndex], spaceIndex, ORDERED_KEYS, context.fields);
+	assert.equal(key, "space");
+	assert.notEqual(key, "value");
+});
+
+test("character context excludes Space and Turn and keeps stock speeds", () => {
+	const context = sixContext();
+	const unrelated = context.extras.slice();
+	filterNonStarshipMovementContext(context, ORDERED_KEYS);
+	const keys = context.types.map(entry => resolveMovementTypeKey(entry, ORDERED_KEYS.indexOf(entry.label), ORDERED_KEYS, context.fields));
+	assert.deepEqual(keys, STOCK_KEYS);
+	assert.equal(context.types.some(entry => entry.name.endsWith(".space") || entry.name.endsWith(".turn")), false);
+	assert.deepEqual(context.extras, unrelated);
+	assert.ok(context.fields.units);
+	assert.ok(context.fields.hover);
+});
+
+test("ordinary vehicle context excludes Space and Turn", () => {
+	const context = sixContext();
+	filterNonStarshipMovementContext(context, ORDERED_KEYS);
+	const names = context.types.map(entry => entry.name);
+	assert.equal(names.includes("system.attributes.movement.speeds.space"), false);
+	assert.equal(names.includes("system.attributes.movement.speeds.turn"), false);
+	assert.ok(names.includes("system.attributes.movement.speeds.walk"));
+	assert.ok(names.includes("system.attributes.movement.speeds.fly"));
+});
+
+test("starship context is unfiltered and retains Space and Turn", () => {
+	const context = sixContext();
+	const names = context.types.map(entry => entry.name);
+	assert.ok(names.includes("system.attributes.movement.speeds.space"));
+	assert.ok(names.includes("system.attributes.movement.speeds.turn"));
+	assert.ok(names.includes("system.attributes.movement.speeds.walk"));
+	assert.equal(context.types.length, ORDERED_KEYS.length);
+});
+
+test("unrelated context entries remain after filter", () => {
+	const extra = { field: { name: "special" }, label: "Special", name: "system.attributes.movement.special", value: "" };
+	const context = sixContext(extra);
+	filterNonStarshipMovementContext(context, ORDERED_KEYS);
+	assert.ok(context.types.some(entry => entry.name === "system.attributes.movement.special"));
+	assert.equal(context.extras.length, 1);
+});
+
+console.log(`\n${passed} passed`);

--- a/utils/test-starship-movement-speeds-path.mjs
+++ b/utils/test-starship-movement-speeds-path.mjs
@@ -1,0 +1,80 @@
+#!/usr/bin/env node
+/**
+ * Pure-logic tests: dnd5e 6.0 Role movement keys live under movement.speeds.
+ * Does not prove Actor preparation, Active Effect application, sheets, or token rulers.
+ */
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+	STARSHIP_ROLE_MOVEMENT_SPACE_KEY,
+	STARSHIP_ROLE_MOVEMENT_TURN_KEY,
+	readStarshipActorMovementSpeeds,
+	resolveStarshipMovementSourceUpdate
+} from "../scripts/starship-data.mjs";
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const SCRIPTS = path.join(ROOT, "scripts");
+const OBSOLETE_SPACE = "system.attributes.movement.space";
+const OBSOLETE_TURN = "system.attributes.movement.turn";
+
+let passed = 0;
+function test(name, fn) {
+	fn();
+	passed += 1;
+	console.log(`ok - ${name}`);
+}
+
+function walkMjs(dir, acc=[]) {
+	for ( const entry of fs.readdirSync(dir, { withFileTypes: true }) ) {
+		const full = path.join(dir, entry.name);
+		if ( entry.isDirectory() ) walkMjs(full, acc);
+		else if ( entry.name.endsWith(".mjs") ) acc.push(full);
+	}
+	return acc;
+}
+
+test("runtime Role AE keys use movement.speeds", () => {
+	assert.equal(STARSHIP_ROLE_MOVEMENT_SPACE_KEY, "system.attributes.movement.speeds.space");
+	assert.equal(STARSHIP_ROLE_MOVEMENT_TURN_KEY, "system.attributes.movement.speeds.turn");
+});
+
+test("readStarshipActorMovementSpeeds uses speeds only", () => {
+	const fromSpeeds = readStarshipActorMovementSpeeds({ speeds: { space: 400, turn: 250 }, space: 1, turn: 2 });
+	assert.equal(fromSpeeds.space, 400);
+	assert.equal(fromSpeeds.turn, 250);
+	const fromSiblings = readStarshipActorMovementSpeeds({ space: 400, turn: 250 });
+	assert.equal(fromSiblings.space, null);
+	assert.equal(fromSiblings.turn, null);
+});
+
+test("source update writes speeds and strips sibling keys", () => {
+	const resolved = resolveStarshipMovementSourceUpdate({
+		underlying: { space: 40, turn: 30 },
+		proposedMovement: { speeds: { space: 55, turn: 44, walk: 30 }, space: 99, units: "ft" },
+		pendingKeys: new Set(["space", "turn", "units"])
+	});
+	assert.equal(resolved.movement.speeds.space, 55);
+	assert.equal(resolved.movement.speeds.turn, 44);
+	assert.equal("walk" in (resolved.movement.speeds ?? {}), false);
+	assert.equal("space" in resolved.movement, false);
+	assert.equal(resolved.movement.units, "ft");
+	assert.deepEqual(resolved.savedFields, ["space", "turn"]);
+});
+
+test("ordinary-vehicle isolation is identification-based (keys remain starship-only constants)", () => {
+	assert.match(STARSHIP_ROLE_MOVEMENT_SPACE_KEY, /\.speeds\.space$/);
+	assert.match(STARSHIP_ROLE_MOVEMENT_TURN_KEY, /\.speeds\.turn$/);
+});
+
+test("obsolete sibling AE keys are absent from scripts/", () => {
+	const hits = [];
+	for ( const file of walkMjs(SCRIPTS) ) {
+		const text = fs.readFileSync(file, "utf8");
+		if ( text.includes(OBSOLETE_SPACE) || text.includes(OBSOLETE_TURN) ) hits.push(path.relative(ROOT, file));
+	}
+	assert.deepEqual(hits, []);
+});
+
+console.log(`\n${passed} passed`);


### PR DESCRIPTION
## Summary
- Adapt SW5e runtime movement, armor-class, and maneuver chat-card surfaces to dnd5e 6.0 (`movement.speeds`, string Active Effect `type`, Movement/Senses filtering).
- Correct starship movement handling so obsolete sibling Role keys are rejected, canonical Space/Turn OVERRIDE applies equally, and non-starship sheets no longer leak Space/Turn.
- Remediate pack Active Effect keys from `system.attributes.movement.space|turn` to `system.attributes.movement.speeds.space|turn` (Roles, Combat Thrusters and related mods, Overload Systems, Drake embeds), rebuild packs, and validate fresh imports.

## Test plan
- [ ] Offline: `node utils/test-starship-movement-pack-keys.mjs`, `node utils/test-role-movement-active-effects.mjs`, `node utils/test-starship-movement-ae-controllers.mjs`, then the complete `utils/test-*.mjs` runnable inventory (77 suites; do not run the migration harness as a suite).
- [ ] Foundry 14.367 / dnd5e 6.0.0 / lib-wrapper only, disposable world `sw5e-v14-dnd5e-600-three-surface`.
- [ ] Character and ordinary-vehicle Movement config have no Space/Turn; starship retains them.
- [ ] Fresh Role Worker import OVERRIDE 350/100 changes prepared speeds and restores; `_source` unchanged.
- [ ] Combat Thrusters Mk I ADD -50 Turn applies and restores; Drake Adaptive Ailerons embedded keys are canonical.
- [ ] Manual canonical Space/Turn AE still applies; token `movementAction` remains `space`; no movement-pipeline `change.mode` warning.
- [ ] Confirm original G-SHIP-03c FAIL / G-SHIP-03c-R1 records are not rewritten; this PR is the pack+runtime follow-up.
